### PR TITLE
Revert to simpler use-api. More stable.

### DIFF
--- a/zio-direct-test/src/test/scala-2.x/zio/direct/Example.scala
+++ b/zio-direct-test/src/test/scala-2.x/zio/direct/Example.scala
@@ -19,7 +19,7 @@ object Example {
   def main(args: Array[String]): Unit = {
 
     val out =
-      defer.use(Use.withLenientCheck) {
+      defer(Use.withLenientCheck) {
         if (true)
           ZIO.fail(Error.ErrorOne(new IOException("foo")))
         else

--- a/zio-direct-test/src/test/scala-3.x/zio/direct/DeferRunSpec.scala
+++ b/zio-direct-test/src/test/scala-3.x/zio/direct/DeferRunSpec.scala
@@ -83,7 +83,7 @@ trait DeferRunSpec extends ZIOSpecDefault {
   }
 
   inline def runLiftTestLenient[T](expected: T)(inline body: T) = {
-    val deferBody = defer.use(Use.withLenientCheck)(body)
+    val deferBody = defer(Use.withLenientCheck)(body)
     // Not sure why but If I don't cast to .asInstanceOf[ZIO[Any, Nothing, ?]]
     // zio says it expects a layer of scala.Nothing
 
@@ -94,7 +94,7 @@ trait DeferRunSpec extends ZIOSpecDefault {
 
   transparent inline def runLiftFailLenientMsg(errorStringContains: String)(body: String) = {
     val errors =
-      typeCheckErrors("defer.use(zio.direct.Use.withLenientCheck) {" + body + "}").map(_.message)
+      typeCheckErrors("defer(zio.direct.Use.withLenientCheck) {" + body + "}").map(_.message)
 
     // assert(errors)(exists(containsString(errorStringContains)))
     zio.test.UseSmartAssert.of(errors, None, None)(exists(containsString(errorStringContains)))(sourceLocation)

--- a/zio-direct-test/src/test/scala/zio/direct/ErrorSpec.scala
+++ b/zio-direct-test/src/test/scala/zio/direct/ErrorSpec.scala
@@ -10,21 +10,21 @@ object ErrorSpec extends DeferRunSpec {
     suite("Different Kinds of ways that errors can be thrown")(
       test("Directly thrown error should always go to error channel") {
         val out =
-          defer.use(Use.withNoCheck) {
+          defer(Use.withNoCheck) {
             throw new FooError
           }
         assertZIO(out.exit)(fails(isSubtype[FooError](anything)))
       },
       test("Indirect error function WITH 'unsafe' should be a failure") {
         val out =
-          defer.use(Use.withNoCheck) {
+          defer(Use.withNoCheck) {
             unsafe { throwFoo() }
           }
         assertZIO(out.exit)(fails(isSubtype[FooError](anything)))
       },
       test("Indirect error function WITHOUT 'unsafe' should be a defect") {
         val out =
-          defer.use(Use.withNoCheck) {
+          defer(Use.withNoCheck) {
             throwFoo()
           }
         assertZIO(out.exit)(dies(isSubtype[FooError](anything)))
@@ -32,7 +32,7 @@ object ErrorSpec extends DeferRunSpec {
       test("Operations order multiple should be correct") {
         var extern = "foo"
         val out =
-          defer.use(Use.withNoCheck) {
+          defer(Use.withNoCheck) {
             extern = extern + "bar"
             extern = extern + "baz"
             throwFoo()
@@ -46,7 +46,7 @@ object ErrorSpec extends DeferRunSpec {
         // a useful test to see if blocks are re-composed correctly.
         var extern = "foo"
         val out =
-          defer.use(Use.withNoCheck) {
+          defer(Use.withNoCheck) {
             extern = extern + "bar"
             ZIO.succeed(extern + "effect").run
             extern = extern + "baz"
@@ -62,7 +62,7 @@ object ErrorSpec extends DeferRunSpec {
       test("External error function without 'unsafe' should be a defect - odd case") {
         var extern = 1
         val out =
-          defer.use(Use.withNoCheck) {
+          defer(Use.withNoCheck) {
             extern = extern + 1
             throwFoo()
             try {
@@ -77,7 +77,7 @@ object ErrorSpec extends DeferRunSpec {
       test("External error function without 'unsafe' should be a defect - odd case + environment") {
         var extern = 1
         val out =
-          defer.use(Use.withNoCheck) {
+          defer(Use.withNoCheck) {
             extern = extern + 1
             throwFoo()
             try {

--- a/zio-direct-test/src/test/scala/zio/direct/ForeachSpec.scala
+++ b/zio-direct-test/src/test/scala/zio/direct/ForeachSpec.scala
@@ -12,7 +12,7 @@ object ForeachSpec extends DeferRunSpec {
       test("List Pure, Body Pure") {
         var v = 1
         val out =
-          defer.use(Use.withLenientCheck) {
+          defer(Use.withLenientCheck) {
             for (i <- List(1, 2, 3)) {
               v += i
             }
@@ -23,7 +23,7 @@ object ForeachSpec extends DeferRunSpec {
       test("List Impure, body Pure") {
         var v = 1
         val out =
-          defer.use(Use.withLenientCheck) {
+          defer(Use.withLenientCheck) {
             for (i <- ZIO.succeed(List(1, 2, 3)).run) {
               v += i
             }
@@ -34,7 +34,7 @@ object ForeachSpec extends DeferRunSpec {
       test("List Pure, body Impure") {
         var v = 1
         val out =
-          defer.use(Use.withLenientCheck) {
+          defer(Use.withLenientCheck) {
             for (i <- List(1, 2, 3)) {
               ZIO.succeed(v += i).run
             }
@@ -45,7 +45,7 @@ object ForeachSpec extends DeferRunSpec {
       test("List Impure, body Impure") {
         var v = 1
         val out =
-          defer.use(Use.withLenientCheck) {
+          defer(Use.withLenientCheck) {
             for (i <- ZIO.succeed(List(1, 2, 3)).run) {
               ZIO.succeed(v += i).run
             }
@@ -58,7 +58,7 @@ object ForeachSpec extends DeferRunSpec {
       test("Dependency in list") {
         var v = 1
         val out =
-          defer.use(Use.withLenientCheck) {
+          defer(Use.withLenientCheck) {
             for (i <- ZIO.service[ConfigT[List[Int]]].run.value) {
               v += i
             }
@@ -73,7 +73,7 @@ object ForeachSpec extends DeferRunSpec {
       test("Dependency in body") {
         var v = 1
         val out =
-          defer.use(Use.withLenientCheck) {
+          defer(Use.withLenientCheck) {
             for (i <- List(1, 2, 3)) {
               val assign = ZIO.service[ConfigInt].run.value
               v += assign + i
@@ -90,7 +90,7 @@ object ForeachSpec extends DeferRunSpec {
       test("Dependency in both") {
         var v = 1
         val out =
-          defer.use(Use.withLenientCheck) {
+          defer(Use.withLenientCheck) {
             for (i <- ZIO.service[ConfigT[List[Int]]].run.value) {
               val assign = ZIO.service[ConfigInt].run.value
               v += assign + i
@@ -110,7 +110,7 @@ object ForeachSpec extends DeferRunSpec {
       test("Throw in List die") {
         var v = 1
         val out =
-          defer.use(Use.withLenientCheck) {
+          defer(Use.withLenientCheck) {
             for (i <- ZIO.succeed(List(1, { throwFoo(); 2 }, 3)).run) {
               ZIO.succeed(v += i).run
             }
@@ -121,7 +121,7 @@ object ForeachSpec extends DeferRunSpec {
       test("Throw in List fail") {
         var v = 1
         val out =
-          defer.use(Use.withLenientCheck) {
+          defer(Use.withLenientCheck) {
             for (i <- unsafe(ZIO.succeed(List(1, { throwFoo(); 2 }, 3)).run)) {
               ZIO.succeed(v += i).run
             }

--- a/zio-direct-test/src/test/scala/zio/direct/ParallelSpec.scala
+++ b/zio-direct-test/src/test/scala/zio/direct/ParallelSpec.scala
@@ -58,7 +58,7 @@ object ParallelSpec extends DeferRunSpec {
         assertZIO(out.exit)(fails(anything))
       },
       test("Inferred Environment both sides error impure - least base type") {
-        val out = defer.use(Use.withAbstractError) {
+        val out = defer(Use.withAbstractError) {
           (fail(makeFooError).run, fail(makeBarError).run)
         }
         assertZIO(out.exit)(fails(anything))

--- a/zio-direct-test/src/test/scala/zio/direct/TrySpec.scala
+++ b/zio-direct-test/src/test/scala/zio/direct/TrySpec.scala
@@ -126,7 +126,7 @@ object TrySpec extends DeferRunSpec {
             assertIsType[ZIO[Any, FooError, Tuple2[Int, Int]]](out)
         },
         test("not caught error in parallel block (die-channel) - both sides") {
-          val out = defer.use(Use.withAbstractError) {
+          val out = defer(Use.withAbstractError) {
             try {
               ({ throw ZIO.succeed(makeFooError).run }, { throw ZIO.succeed(makeBarError).run })
             } catch {
@@ -170,7 +170,7 @@ object TrySpec extends DeferRunSpec {
       def c() = called = true
       // runLiftTest(true)
       val out =
-        defer.use(Use.withLenientCheck) {
+        defer(Use.withLenientCheck) {
           val _ =
             try 1
             catch {

--- a/zio-direct-test/src/test/scala/zio/direct/WhileSpec.scala
+++ b/zio-direct-test/src/test/scala/zio/direct/WhileSpec.scala
@@ -12,7 +12,7 @@ object WhileSpec extends DeferRunSpec {
     suite("run condition")(
       test("pure body") {
         val out =
-          defer.use(Use.withLenientCheck) {
+          defer(Use.withLenientCheck) {
             var i = 0
             while (runBlock(succeed(i)) < 3)
               succeed(i += 1).run
@@ -22,7 +22,7 @@ object WhileSpec extends DeferRunSpec {
       },
       test("impure body") {
         val out =
-          defer.use(Use.withLenientCheck) {
+          defer(Use.withLenientCheck) {
             var i = 0
             while (runBlock(succeed(i)) < 3) {
               val add = succeed(1).run
@@ -36,7 +36,7 @@ object WhileSpec extends DeferRunSpec {
     suite("pure condition")(
       test("pure body") {
         val out =
-          defer.use(Use.withLenientCheck) {
+          defer(Use.withLenientCheck) {
             var i = 0
             while (i < 3)
               succeed(i += 1).run
@@ -59,7 +59,7 @@ object WhileSpec extends DeferRunSpec {
           i
         }
         val out =
-          defer.use(Use.withLenientCheck) {
+          defer(Use.withLenientCheck) {
             while (i < 3)
               (succeed(incrementA()).run, succeed(incrementB()).run)
             i

--- a/zio-direct-test/src/test/scala/zio/direct/examples/FunctionalVsDirect.scala
+++ b/zio-direct-test/src/test/scala/zio/direct/examples/FunctionalVsDirect.scala
@@ -34,7 +34,7 @@
 //       // original imperative code
 //       {
 
-//         defer.use(Use.withNoCheck) {
+//         defer(Use.withNoCheck) {
 //           val db = Database.open
 //           while (db.hasNextRow()) {
 //             if (!db.lockNextRow()) doSomethingWith(db.nextRow()) else waitT()

--- a/zio-direct-test/src/test/scala/zio/direct/examples/IntroductionExamples.scala
+++ b/zio-direct-test/src/test/scala/zio/direct/examples/IntroductionExamples.scala
@@ -310,7 +310,7 @@
 //       makeFile().flatMap { file =>
 //         val buffer = new StringBuffer()
 
-//         defer.use(Use.withLenientCheck) {
+//         defer(Use.withLenientCheck) {
 //           val line0 = file.readLine().run
 //           var line: String = line0
 //           while (line != null) {
@@ -348,7 +348,7 @@
 
 //       makeFile().flatMap { file =>
 //         val buffer = new StringBuffer()
-//         defer.use(Use.withLenientCheck) {
+//         defer(Use.withLenientCheck) {
 //           val line0 = file.readLine().run
 //           var line: String = line0
 //           while (line != null) {

--- a/zio-direct-test/src/test/scala/zio/direct/examples/Quicksort.scala
+++ b/zio-direct-test/src/test/scala/zio/direct/examples/Quicksort.scala
@@ -12,7 +12,7 @@
 //       arr(j) = temp
 //     }
 
-//     def sort(l: Int, r: Int): ZIO[Any, Nothing, Unit] = defer.use(Use.withLenientCheck) {
+//     def sort(l: Int, r: Int): ZIO[Any, Nothing, Unit] = defer(Use.withLenientCheck) {
 //       val pivot = arr((l + r) / 2)
 //       val i = Ref.make(l).run
 //       val j = Ref.make(r).run

--- a/zio-direct/src/main/scala-2.x/zio/direct/dsl.scala
+++ b/zio-direct/src/main/scala-2.x/zio/direct/dsl.scala
@@ -9,27 +9,16 @@ package object direct {
 
   object defer {
     def apply[T](value: T): ZIO[_, _, _] = macro core.Macro.defer[T]
-    def use[T](use: Use)(value: T): ZIO[_, _, _] = macro core.Macro.deferWithUse[T]
+    def tpe[T](value: T): ZIO[_, _, _] = macro core.Macro.tpe[T]
+    def info[T](value: T): ZIO[_, _, _] = macro core.Macro.info[T]
+    def verbose[T](value: T): ZIO[_, _, _] = macro core.Macro.verbose[T]
+    def verboseTree[T](value: T): ZIO[_, _, _] = macro core.Macro.verboseTree[T]
 
-    object tpe {
-      def apply[T](value: T): ZIO[_, _, _] = macro core.Macro.tpe[T]
-      def use[T](use: Use)(value: T): ZIO[_, _, _] = macro core.Macro.tpeWithUse[T]
-    }
-
-    object info {
-      def apply[T](value: T): ZIO[_, _, _] = macro core.Macro.info[T]
-      def use[T](use: Use)(value: T): ZIO[_, _, _] = macro core.Macro.infoWithUse[T]
-    }
-
-    object verbose {
-      def apply[T](value: T): ZIO[_, _, _] = macro core.Macro.verbose[T]
-      def use[T](use: Use)(value: T): ZIO[_, _, _] = macro core.Macro.verboseWithUse[T]
-    }
-
-    object verboseTree {
-      def apply[T](value: T): ZIO[_, _, _] = macro core.Macro.verboseTree[T]
-      def use[T](use: Use)(value: T): ZIO[_, _, _] = macro core.Macro.verboseTreeWithUse[T]
-    }
+    def apply[T](use: Use)(value: T): ZIO[_, _, _] = macro core.Macro.deferWithUse[T]
+    def tpe[T](use: Use)(value: T): ZIO[_, _, _] = macro core.Macro.tpeWithUse[T]
+    def info[T](use: Use)(value: T): ZIO[_, _, _] = macro core.Macro.infoWithUse[T]
+    def verbose[T](use: Use)(value: T): ZIO[_, _, _] = macro core.Macro.verboseWithUse[T]
+    def verboseTree[T](use: Use)(value: T): ZIO[_, _, _] = macro core.Macro.verboseTreeWithUse[T]
   }
 
   implicit class ZioRunOps[R, E, A](value: ZIO[R, E, A]) {

--- a/zio-direct/src/main/scala-3.x/zio/direct/Dsl.scala
+++ b/zio-direct/src/main/scala-3.x/zio/direct/Dsl.scala
@@ -18,19 +18,14 @@ def unsafe[T](value: T): T = NotDeferredException.fromNamed("unsafe")
 
 object defer {
   transparent inline def apply[T](inline value: T): ZIO[?, ?, ?] = ${ Dsl.impl[T]('value, '{ InfoBehavior.Silent }, '{ Use }) }
-  transparent inline def use[T](inline params: Use)(inline value: T): ZIO[?, ?, ?] = ${ Dsl.impl[T]('value, '{ InfoBehavior.Silent }, 'params) }
+  transparent inline def info[T](inline value: T): ZIO[?, ?, ?] = ${ Dsl.impl[T]('value, '{ InfoBehavior.Info }, '{ Use }) }
+  transparent inline def verbose[T](inline value: T): ZIO[?, ?, ?] = ${ Dsl.impl[T]('value, '{ InfoBehavior.Verbose }, '{ Use }) }
+  transparent inline def verboseTree[T](inline value: T): ZIO[?, ?, ?] = ${ Dsl.impl[T]('value, '{ InfoBehavior.VerboseTree }, '{ Use }) }
 
-  object info:
-    transparent inline def apply[T](inline value: T): ZIO[?, ?, ?] = ${ Dsl.impl[T]('value, '{ InfoBehavior.Info }, '{ Use }) }
-    transparent inline def use[T](inline params: Use)(inline value: T): ZIO[?, ?, ?] = ${ Dsl.impl[T]('value, '{ InfoBehavior.Info }, 'params) }
-
-  object verbose:
-    transparent inline def apply[T](inline value: T): ZIO[?, ?, ?] = ${ Dsl.impl[T]('value, '{ InfoBehavior.Verbose }, '{ Use }) }
-    transparent inline def use[T](inline params: Use)(inline value: T): ZIO[?, ?, ?] = ${ Dsl.impl[T]('value, '{ InfoBehavior.Verbose }, 'params) }
-
-  object verboseTree:
-    transparent inline def apply[T](inline value: T): ZIO[?, ?, ?] = ${ Dsl.impl[T]('value, '{ InfoBehavior.VerboseTree }, '{ Use }) }
-    transparent inline def use[T](inline params: Use)(inline value: T): ZIO[?, ?, ?] = ${ Dsl.impl[T]('value, '{ InfoBehavior.VerboseTree }, 'params) }
+  transparent inline def apply[T](inline params: Use)(inline value: T): ZIO[?, ?, ?] = ${ Dsl.impl[T]('value, '{ InfoBehavior.Silent }, 'params) }
+  transparent inline def info[T](inline params: Use)(inline value: T): ZIO[?, ?, ?] = ${ Dsl.impl[T]('value, '{ InfoBehavior.Info }, 'params) }
+  transparent inline def verbose[T](inline params: Use)(inline value: T): ZIO[?, ?, ?] = ${ Dsl.impl[T]('value, '{ InfoBehavior.Verbose }, 'params) }
+  transparent inline def verboseTree[T](inline params: Use)(inline value: T): ZIO[?, ?, ?] = ${ Dsl.impl[T]('value, '{ InfoBehavior.VerboseTree }, 'params) }
 }
 
 extension [R, E, A](value: ZIO[R, E, A]) {

--- a/zio-direct/src/test/scala-2.x/zio/direct/testing/TestSupport.scala
+++ b/zio-direct/src/test/scala-2.x/zio/direct/testing/TestSupport.scala
@@ -87,9 +87,9 @@ private[direct] class TestSupportMacro(val c: Context) extends Transformer {
   private def wrapDefer(body: String, verify: Verify = Verify.Strict) = {
     verify match {
       case Verify.Lenient =>
-        "defer.use(zio.direct.Use.withLenientCheck) {\n" + body + "\n}"
+        "defer(zio.direct.Use.withLenientCheck) {\n" + body + "\n}"
       case Verify.None =>
-        "defer.use(zio.direct.Use.withNoCheck) {\n" + body + "\n}"
+        "defer(zio.direct.Use.withNoCheck) {\n" + body + "\n}"
       case Verify.Strict =>
         "defer {\n" + body + "\n}"
     }


### PR DESCRIPTION
Crazy issue happens requiring a twin defer method to be used:
```
  def defer[T](value: T): ZIO[_, _, _] = macro core.Macro.deferImpl[T]
  def defer[T](regex: Something)(value: T): ZIO[_, _, _] = ???
```
> The `Something` class can be anything. I tried java.util.Regex which has nothing to do with anything.
In order to do this:
```
        val out =
          defer {
            val i = Ref.make(0).run
            while (i.get.run < 3)
              i.getAndUpdate(i => i + 1).run
            i.get.run
          }
```
Otherwise it reports a crazy error:
```
[error] /home/me/Example.scala:14:5: macro has not been expanded
[error]     defer {
[error]     ^
```
Have a look at this branch for more detail on the issue:
https://github.com/zio/zio-direct/tree/crazy-macro-expansion-error

For now we are just reverting the change and going back to the previous way of doing the Use-object methods API because it seems more stable.

