### PR TITLE
update zio-direct-intellij to a correct version

### DIFF
--- a/zio-direct/src/main/resources/META-INF/intellij-compat.json
+++ b/zio-direct/src/main/resources/META-INF/intellij-compat.json
@@ -1,3 +1,3 @@
 {
-  "artifact": "dev.zio % zio-direct-intellij_2.13 % 1.0.0-RC2-SNAPSHOT"
+  "artifact": "dev.zio % zio-direct-intellij_2.13 % 1.0.0-RC3"
 }


### PR DESCRIPTION
This change updates the zio-direct-intellij version to the latest published `1.0.0-RC3`.
Current version `1.0.0-RC2-SNAPSHOT` is not even published to Maven