### PR TITLE
Remove ZIO references in WithReconstructTree and use WithResolver

### DIFF
--- a/zio-direct-test/src/test/scala/zio/direct/VariaSpec.scala
+++ b/zio-direct-test/src/test/scala/zio/direct/VariaSpec.scala
@@ -1,205 +1,205 @@
-// package zio.direct
+package zio.direct
 
-// import zio.direct.{run => runBlock}
-// import zio.test._
-// import zio.test.Assertion._
-// import zio._
-// import ZIO.{unsafe => _, _}
-// import zio.direct.core.util.Messages
-// import scala.annotation.nowarn
+import zio.direct.{run => runBlock}
+import zio.test._
+import zio.test.Assertion._
+import zio._
+import ZIO.{unsafe => _, _}
+import zio.direct.core.util.Messages
+import scala.annotation.nowarn
 
-// @nowarn
-// object VariaSpec extends DeferRunSpec {
-//   case class Config1(value: Int)
-//   case class Config2(value: Int)
-//   case class Config3(value: Int)
-//   case class Config4(value: Int)
+@nowarn
+object VariaSpec extends DeferRunSpec {
+  case class Config1(value: Int)
+  case class Config2(value: Int)
+  case class Config3(value: Int)
+  case class Config4(value: Int)
 
-//   class SomeService private (var isOpen: Boolean) {
-//     def close(): Unit = { isOpen = false }
-//   }
-//   object SomeService {
-//     def open() = new SomeService(true)
-//   }
+  class SomeService private (var isOpen: Boolean) {
+    def close(): Unit = { isOpen = false }
+  }
+  object SomeService {
+    def open() = new SomeService(true)
+  }
 
-//   val spec = suite("VariaSpec")(
-//     suite("odd placements of defer/run")(
-//       test("defer in defer") {
-//         val out =
-//           defer {
-//             val v = defer {
-//               val env = ZIO.service[ConfigInt].run
-//               env
-//             }
-//             v.run.value + 1
-//           }
-//         assertZIO(out.provide(ZLayer.succeed(ConfigInt(3))))(equalTo(4))
-//       },
-//       test("four services") {
-//         val out =
-//           defer {
-//             val (x, y) = (ZIO.service[Config1].run.value, ZIO.service[Config2].run.value)
-//             val config = ZIO.service[Config3].run
-//             x + config.value + y + ZIO.service[Config4].run.value
-//           }
-//         val provided =
-//           out.provide(
-//             ZLayer.succeed(Config1(1)),
-//             ZLayer.succeed(Config2(2)),
-//             ZLayer.succeed(Config3(3)),
-//             ZLayer.succeed(Config4(4))
-//           )
-//         assertZIO(provided)(equalTo(10))
-//       },
-//       test("services with match statement") {
-//         val out =
-//           defer {
-//             val configValue =
-//               ZIO.service[Config1].run match {
-//                 case Config1(value) => value + ZIO.service[Config2].run.value
-//               }
-//             configValue + ZIO.service[Config3].run.value
-//           }
-//         val provided =
-//           out.provide(
-//             ZLayer.succeed(Config1(1)),
-//             ZLayer.succeed(Config2(2)),
-//             ZLayer.succeed(Config3(4))
-//           )
-//         assertZIO(provided)(equalTo(7))
-//       },
-//       test("using scope") {
-//         val out =
-//           defer {
-//             // Environment type `Any with Any with zio.Scope` is a direct result of this
-//             // ZIO-call so cannot do anything about it in the macros.
-//             val value = ZIO.acquireRelease(ZIO.succeed(SomeService.open()))(svc => ZIO.succeed(svc.close())).run
-//             value.isOpen
-//           }
-//         val withScope =
-//           scoped { out }
-//         assertZIO(withScope)(equalTo(true))
-//       },
-//       test("double tuple deconstruct") {
-//         val out =
-//           defer {
-//             val (x, y) = (ZIO.succeed("foo").run, ZIO.succeed("bar").run)
-//             val (x1, y1) = (ZIO.succeed("A" + x).run, ZIO.succeed("B" + y).run)
-//             x + x1 + y + y1
-//           }
-//         assertZIO(out)(equalTo("fooAfoobarBbar"))
-//       },
-//       test("multi zios in run") {
-//         val out = defer {
-//           if (
-//             runBlock({
-//               for {
-//                 env <- ZIO.service[ConfigInt]
-//                 value <- ZIO.succeed(env.value)
-//               } yield (value)
-//             }) == 123
-//           )
-//             "foo"
-//           else
-//             "bar"
-//         }
-//         val providedA =
-//           out.provide(
-//             ZLayer.succeed(ConfigInt(123))
-//           )
-//         val providedB =
-//           out.provide(
-//             ZLayer.succeed(ConfigInt(456))
-//           )
-//         for {
-//           a <- providedA
-//           b <- providedB
-//         } yield {
-//           assert(a)(equalTo("foo")) && assert(b)(equalTo("bar"))
-//         }
-//       },
-//       test("catch run inside run") {
-//         val msg = Messages.RunRemainingAfterTransformer
-//         import zio.direct.Internal.ignore
-//         runLiftFailMsg(msg) {
-//           """
-//           val x = succeed(123).run
-//           val y =
-//             ignore {
-//               succeed(456).run
-//             }
-//           x + y
-//           """
-//         }
-//       },
-//       test("disallow mutable collection use") {
-//         import scala.collection.mutable.ArrayBuffer
-//         val v = new ArrayBuffer[Int](4)
-//         runLiftFailMsg(Messages.MutableCollectionDetected) {
-//           """
-//           v += 4
-//           """
-//         }
-//       },
-//       test("disallow mutable collection use - declare but not use") {
-//         import scala.collection.mutable.ArrayBuffer
-//         runLiftFailMsg(Messages.MutableCollectionDetected) {
-//           """
-//           val v = new ArrayBuffer[Int](4)
-//           ZIO.succeed(123).run
-//           """
-//         }
-//       },
-//       test("disallow implicit defs") {
-//         runLiftFailMsg(Messages.ImplicitsNotAllowed) {
-//           """
-//           implicit val x = 123
-//           x
-//           """
-//         }
-//       },
-//       test("deconstruct and import") {
-//         class Blah(val value: Int)
-//         runLiftTest(4) {
-//           val (a, a1) = runBlock(ZIO.succeed((1, 2)))
-//           val blah = new Blah(3)
-//           import blah._
-//           val b = runBlock(ZIO.succeed(value))
-//           a + b
-//         }
-//       },
-//       test("deconstruct and multiple import") {
-//         class Blah(val value: Int)
-//         class Blah0(val value0: Int)
-//         class Blah1(val value1: Int)
-//         runLiftTest(6) {
-//           val blah0 = new Blah0(1)
-//           import blah0._
-//           val blah1 = new Blah1(2)
-//           import blah1._
-//           val (a, a1) = ZIO.succeed((value0, value1)).run
-//           val blah = new Blah(3)
-//           import blah._
-//           val b = ZIO.succeed(value).run
-//           a + a1 + b
-//         }
-//       },
-//       test("disallow implicit mutable use") {
-//         var x = 1
-//         runLiftFailMsg(Messages.MutableAndLazyVariablesNotAllowed) {
-//           """
-//           val y = x
-//           """
-//         }
-//       },
-//       test("disallow implicit mutable use") {
-//         var x = 1
-//         runLiftFailMsg(Messages.DeclarationNotAllowed) {
-//           """
-//           lazy val x = 123
-//           """
-//         }
-//       }
-//     )
-//   )
-// }
+  val spec = suite("VariaSpec")(
+    suite("odd placements of defer/run")(
+      test("defer in defer") {
+        val out =
+          defer {
+            val v = defer {
+              val env = ZIO.service[ConfigInt].run
+              env
+            }
+            v.run.value + 1
+          }
+        assertZIO(out.provide(ZLayer.succeed(ConfigInt(3))))(equalTo(4))
+      },
+      test("four services") {
+        val out =
+          defer {
+            val (x, y) = (ZIO.service[Config1].run.value, ZIO.service[Config2].run.value)
+            val config = ZIO.service[Config3].run
+            x + config.value + y + ZIO.service[Config4].run.value
+          }
+        val provided =
+          out.provide(
+            ZLayer.succeed(Config1(1)),
+            ZLayer.succeed(Config2(2)),
+            ZLayer.succeed(Config3(3)),
+            ZLayer.succeed(Config4(4))
+          )
+        assertZIO(provided)(equalTo(10))
+      },
+      test("services with match statement") {
+        val out =
+          defer {
+            val configValue =
+              ZIO.service[Config1].run match {
+                case Config1(value) => value + ZIO.service[Config2].run.value
+              }
+            configValue + ZIO.service[Config3].run.value
+          }
+        val provided =
+          out.provide(
+            ZLayer.succeed(Config1(1)),
+            ZLayer.succeed(Config2(2)),
+            ZLayer.succeed(Config3(4))
+          )
+        assertZIO(provided)(equalTo(7))
+      },
+      test("using scope") {
+        val out =
+          defer {
+            // Environment type `Any with Any with zio.Scope` is a direct result of this
+            // ZIO-call so cannot do anything about it in the macros.
+            val value = ZIO.acquireRelease(ZIO.succeed(SomeService.open()))(svc => ZIO.succeed(svc.close())).run
+            value.isOpen
+          }
+        val withScope =
+          scoped { out }
+        assertZIO(withScope)(equalTo(true))
+      },
+      test("double tuple deconstruct") {
+        val out =
+          defer {
+            val (x, y) = (ZIO.succeed("foo").run, ZIO.succeed("bar").run)
+            val (x1, y1) = (ZIO.succeed("A" + x).run, ZIO.succeed("B" + y).run)
+            x + x1 + y + y1
+          }
+        assertZIO(out)(equalTo("fooAfoobarBbar"))
+      },
+      test("multi zios in run") {
+        val out = defer {
+          if (
+            runBlock({
+              for {
+                env <- ZIO.service[ConfigInt]
+                value <- ZIO.succeed(env.value)
+              } yield (value)
+            }) == 123
+          )
+            "foo"
+          else
+            "bar"
+        }
+        val providedA =
+          out.provide(
+            ZLayer.succeed(ConfigInt(123))
+          )
+        val providedB =
+          out.provide(
+            ZLayer.succeed(ConfigInt(456))
+          )
+        for {
+          a <- providedA
+          b <- providedB
+        } yield {
+          assert(a)(equalTo("foo")) && assert(b)(equalTo("bar"))
+        }
+      },
+      test("catch run inside run") {
+        val msg = Messages.RunRemainingAfterTransformer
+        import zio.direct.Internal.ignore
+        runLiftFailMsg(msg) {
+          """
+          val x = succeed(123).run
+          val y =
+            ignore {
+              succeed(456).run
+            }
+          x + y
+          """
+        }
+      },
+      test("disallow mutable collection use") {
+        import scala.collection.mutable.ArrayBuffer
+        val v = new ArrayBuffer[Int](4)
+        runLiftFailMsg(Messages.MutableCollectionDetected) {
+          """
+          v += 4
+          """
+        }
+      },
+      test("disallow mutable collection use - declare but not use") {
+        import scala.collection.mutable.ArrayBuffer
+        runLiftFailMsg(Messages.MutableCollectionDetected) {
+          """
+          val v = new ArrayBuffer[Int](4)
+          ZIO.succeed(123).run
+          """
+        }
+      },
+      test("disallow implicit defs") {
+        runLiftFailMsg(Messages.ImplicitsNotAllowed) {
+          """
+          implicit val x = 123
+          x
+          """
+        }
+      },
+      test("deconstruct and import") {
+        class Blah(val value: Int)
+        runLiftTest(4) {
+          val (a, a1) = runBlock(ZIO.succeed((1, 2)))
+          val blah = new Blah(3)
+          import blah._
+          val b = runBlock(ZIO.succeed(value))
+          a + b
+        }
+      },
+      test("deconstruct and multiple import") {
+        class Blah(val value: Int)
+        class Blah0(val value0: Int)
+        class Blah1(val value1: Int)
+        runLiftTest(6) {
+          val blah0 = new Blah0(1)
+          import blah0._
+          val blah1 = new Blah1(2)
+          import blah1._
+          val (a, a1) = ZIO.succeed((value0, value1)).run
+          val blah = new Blah(3)
+          import blah._
+          val b = ZIO.succeed(value).run
+          a + a1 + b
+        }
+      },
+      test("disallow implicit mutable use") {
+        var x = 1
+        runLiftFailMsg(Messages.MutableAndLazyVariablesNotAllowed) {
+          """
+          val y = x
+          """
+        }
+      },
+      test("disallow implicit mutable use") {
+        var x = 1
+        runLiftFailMsg(Messages.DeclarationNotAllowed) {
+          """
+          lazy val x = 123
+          """
+        }
+      }
+    )
+  )
+}

--- a/zio-direct-test/src/test/scala/zio/direct/VariaSpec.scala
+++ b/zio-direct-test/src/test/scala/zio/direct/VariaSpec.scala
@@ -1,205 +1,205 @@
-package zio.direct
+// package zio.direct
 
-import zio.direct.{run => runBlock}
-import zio.test._
-import zio.test.Assertion._
-import zio._
-import ZIO.{unsafe => _, _}
-import zio.direct.core.util.Messages
-import scala.annotation.nowarn
+// import zio.direct.{run => runBlock}
+// import zio.test._
+// import zio.test.Assertion._
+// import zio._
+// import ZIO.{unsafe => _, _}
+// import zio.direct.core.util.Messages
+// import scala.annotation.nowarn
 
-@nowarn
-object VariaSpec extends DeferRunSpec {
-  case class Config1(value: Int)
-  case class Config2(value: Int)
-  case class Config3(value: Int)
-  case class Config4(value: Int)
+// @nowarn
+// object VariaSpec extends DeferRunSpec {
+//   case class Config1(value: Int)
+//   case class Config2(value: Int)
+//   case class Config3(value: Int)
+//   case class Config4(value: Int)
 
-  class SomeService private (var isOpen: Boolean) {
-    def close(): Unit = { isOpen = false }
-  }
-  object SomeService {
-    def open() = new SomeService(true)
-  }
+//   class SomeService private (var isOpen: Boolean) {
+//     def close(): Unit = { isOpen = false }
+//   }
+//   object SomeService {
+//     def open() = new SomeService(true)
+//   }
 
-  val spec = suite("VariaSpec")(
-    suite("odd placements of defer/run")(
-      test("defer in defer") {
-        val out =
-          defer {
-            val v = defer {
-              val env = ZIO.service[ConfigInt].run
-              env
-            }
-            v.run.value + 1
-          }
-        assertZIO(out.provide(ZLayer.succeed(ConfigInt(3))))(equalTo(4))
-      },
-      test("four services") {
-        val out =
-          defer {
-            val (x, y) = (ZIO.service[Config1].run.value, ZIO.service[Config2].run.value)
-            val config = ZIO.service[Config3].run
-            x + config.value + y + ZIO.service[Config4].run.value
-          }
-        val provided =
-          out.provide(
-            ZLayer.succeed(Config1(1)),
-            ZLayer.succeed(Config2(2)),
-            ZLayer.succeed(Config3(3)),
-            ZLayer.succeed(Config4(4))
-          )
-        assertZIO(provided)(equalTo(10))
-      },
-      test("services with match statement") {
-        val out =
-          defer {
-            val configValue =
-              ZIO.service[Config1].run match {
-                case Config1(value) => value + ZIO.service[Config2].run.value
-              }
-            configValue + ZIO.service[Config3].run.value
-          }
-        val provided =
-          out.provide(
-            ZLayer.succeed(Config1(1)),
-            ZLayer.succeed(Config2(2)),
-            ZLayer.succeed(Config3(4))
-          )
-        assertZIO(provided)(equalTo(7))
-      },
-      test("using scope") {
-        val out =
-          defer {
-            // Environment type `Any with Any with zio.Scope` is a direct result of this
-            // ZIO-call so cannot do anything about it in the macros.
-            val value = ZIO.acquireRelease(ZIO.succeed(SomeService.open()))(svc => ZIO.succeed(svc.close())).run
-            value.isOpen
-          }
-        val withScope =
-          scoped { out }
-        assertZIO(withScope)(equalTo(true))
-      },
-      test("double tuple deconstruct") {
-        val out =
-          defer {
-            val (x, y) = (ZIO.succeed("foo").run, ZIO.succeed("bar").run)
-            val (x1, y1) = (ZIO.succeed("A" + x).run, ZIO.succeed("B" + y).run)
-            x + x1 + y + y1
-          }
-        assertZIO(out)(equalTo("fooAfoobarBbar"))
-      },
-      test("multi zios in run") {
-        val out = defer {
-          if (
-            runBlock({
-              for {
-                env <- ZIO.service[ConfigInt]
-                value <- ZIO.succeed(env.value)
-              } yield (value)
-            }) == 123
-          )
-            "foo"
-          else
-            "bar"
-        }
-        val providedA =
-          out.provide(
-            ZLayer.succeed(ConfigInt(123))
-          )
-        val providedB =
-          out.provide(
-            ZLayer.succeed(ConfigInt(456))
-          )
-        for {
-          a <- providedA
-          b <- providedB
-        } yield {
-          assert(a)(equalTo("foo")) && assert(b)(equalTo("bar"))
-        }
-      },
-      test("catch run inside run") {
-        val msg = Messages.RunRemainingAfterTransformer
-        import zio.direct.Internal.ignore
-        runLiftFailMsg(msg) {
-          """
-          val x = succeed(123).run
-          val y =
-            ignore {
-              succeed(456).run
-            }
-          x + y
-          """
-        }
-      },
-      test("disallow mutable collection use") {
-        import scala.collection.mutable.ArrayBuffer
-        val v = new ArrayBuffer[Int](4)
-        runLiftFailMsg(Messages.MutableCollectionDetected) {
-          """
-          v += 4
-          """
-        }
-      },
-      test("disallow mutable collection use - declare but not use") {
-        import scala.collection.mutable.ArrayBuffer
-        runLiftFailMsg(Messages.MutableCollectionDetected) {
-          """
-          val v = new ArrayBuffer[Int](4)
-          ZIO.succeed(123).run
-          """
-        }
-      },
-      test("disallow implicit defs") {
-        runLiftFailMsg(Messages.ImplicitsNotAllowed) {
-          """
-          implicit val x = 123
-          x
-          """
-        }
-      },
-      test("deconstruct and import") {
-        class Blah(val value: Int)
-        runLiftTest(4) {
-          val (a, a1) = runBlock(ZIO.succeed((1, 2)))
-          val blah = new Blah(3)
-          import blah._
-          val b = runBlock(ZIO.succeed(value))
-          a + b
-        }
-      },
-      test("deconstruct and multiple import") {
-        class Blah(val value: Int)
-        class Blah0(val value0: Int)
-        class Blah1(val value1: Int)
-        runLiftTest(6) {
-          val blah0 = new Blah0(1)
-          import blah0._
-          val blah1 = new Blah1(2)
-          import blah1._
-          val (a, a1) = ZIO.succeed((value0, value1)).run
-          val blah = new Blah(3)
-          import blah._
-          val b = ZIO.succeed(value).run
-          a + a1 + b
-        }
-      },
-      test("disallow implicit mutable use") {
-        var x = 1
-        runLiftFailMsg(Messages.MutableAndLazyVariablesNotAllowed) {
-          """
-          val y = x
-          """
-        }
-      },
-      test("disallow implicit mutable use") {
-        var x = 1
-        runLiftFailMsg(Messages.DeclarationNotAllowed) {
-          """
-          lazy val x = 123
-          """
-        }
-      }
-    )
-  )
-}
+//   val spec = suite("VariaSpec")(
+//     suite("odd placements of defer/run")(
+//       test("defer in defer") {
+//         val out =
+//           defer {
+//             val v = defer {
+//               val env = ZIO.service[ConfigInt].run
+//               env
+//             }
+//             v.run.value + 1
+//           }
+//         assertZIO(out.provide(ZLayer.succeed(ConfigInt(3))))(equalTo(4))
+//       },
+//       test("four services") {
+//         val out =
+//           defer {
+//             val (x, y) = (ZIO.service[Config1].run.value, ZIO.service[Config2].run.value)
+//             val config = ZIO.service[Config3].run
+//             x + config.value + y + ZIO.service[Config4].run.value
+//           }
+//         val provided =
+//           out.provide(
+//             ZLayer.succeed(Config1(1)),
+//             ZLayer.succeed(Config2(2)),
+//             ZLayer.succeed(Config3(3)),
+//             ZLayer.succeed(Config4(4))
+//           )
+//         assertZIO(provided)(equalTo(10))
+//       },
+//       test("services with match statement") {
+//         val out =
+//           defer {
+//             val configValue =
+//               ZIO.service[Config1].run match {
+//                 case Config1(value) => value + ZIO.service[Config2].run.value
+//               }
+//             configValue + ZIO.service[Config3].run.value
+//           }
+//         val provided =
+//           out.provide(
+//             ZLayer.succeed(Config1(1)),
+//             ZLayer.succeed(Config2(2)),
+//             ZLayer.succeed(Config3(4))
+//           )
+//         assertZIO(provided)(equalTo(7))
+//       },
+//       test("using scope") {
+//         val out =
+//           defer {
+//             // Environment type `Any with Any with zio.Scope` is a direct result of this
+//             // ZIO-call so cannot do anything about it in the macros.
+//             val value = ZIO.acquireRelease(ZIO.succeed(SomeService.open()))(svc => ZIO.succeed(svc.close())).run
+//             value.isOpen
+//           }
+//         val withScope =
+//           scoped { out }
+//         assertZIO(withScope)(equalTo(true))
+//       },
+//       test("double tuple deconstruct") {
+//         val out =
+//           defer {
+//             val (x, y) = (ZIO.succeed("foo").run, ZIO.succeed("bar").run)
+//             val (x1, y1) = (ZIO.succeed("A" + x).run, ZIO.succeed("B" + y).run)
+//             x + x1 + y + y1
+//           }
+//         assertZIO(out)(equalTo("fooAfoobarBbar"))
+//       },
+//       test("multi zios in run") {
+//         val out = defer {
+//           if (
+//             runBlock({
+//               for {
+//                 env <- ZIO.service[ConfigInt]
+//                 value <- ZIO.succeed(env.value)
+//               } yield (value)
+//             }) == 123
+//           )
+//             "foo"
+//           else
+//             "bar"
+//         }
+//         val providedA =
+//           out.provide(
+//             ZLayer.succeed(ConfigInt(123))
+//           )
+//         val providedB =
+//           out.provide(
+//             ZLayer.succeed(ConfigInt(456))
+//           )
+//         for {
+//           a <- providedA
+//           b <- providedB
+//         } yield {
+//           assert(a)(equalTo("foo")) && assert(b)(equalTo("bar"))
+//         }
+//       },
+//       test("catch run inside run") {
+//         val msg = Messages.RunRemainingAfterTransformer
+//         import zio.direct.Internal.ignore
+//         runLiftFailMsg(msg) {
+//           """
+//           val x = succeed(123).run
+//           val y =
+//             ignore {
+//               succeed(456).run
+//             }
+//           x + y
+//           """
+//         }
+//       },
+//       test("disallow mutable collection use") {
+//         import scala.collection.mutable.ArrayBuffer
+//         val v = new ArrayBuffer[Int](4)
+//         runLiftFailMsg(Messages.MutableCollectionDetected) {
+//           """
+//           v += 4
+//           """
+//         }
+//       },
+//       test("disallow mutable collection use - declare but not use") {
+//         import scala.collection.mutable.ArrayBuffer
+//         runLiftFailMsg(Messages.MutableCollectionDetected) {
+//           """
+//           val v = new ArrayBuffer[Int](4)
+//           ZIO.succeed(123).run
+//           """
+//         }
+//       },
+//       test("disallow implicit defs") {
+//         runLiftFailMsg(Messages.ImplicitsNotAllowed) {
+//           """
+//           implicit val x = 123
+//           x
+//           """
+//         }
+//       },
+//       test("deconstruct and import") {
+//         class Blah(val value: Int)
+//         runLiftTest(4) {
+//           val (a, a1) = runBlock(ZIO.succeed((1, 2)))
+//           val blah = new Blah(3)
+//           import blah._
+//           val b = runBlock(ZIO.succeed(value))
+//           a + b
+//         }
+//       },
+//       test("deconstruct and multiple import") {
+//         class Blah(val value: Int)
+//         class Blah0(val value0: Int)
+//         class Blah1(val value1: Int)
+//         runLiftTest(6) {
+//           val blah0 = new Blah0(1)
+//           import blah0._
+//           val blah1 = new Blah1(2)
+//           import blah1._
+//           val (a, a1) = ZIO.succeed((value0, value1)).run
+//           val blah = new Blah(3)
+//           import blah._
+//           val b = ZIO.succeed(value).run
+//           a + a1 + b
+//         }
+//       },
+//       test("disallow implicit mutable use") {
+//         var x = 1
+//         runLiftFailMsg(Messages.MutableAndLazyVariablesNotAllowed) {
+//           """
+//           val y = x
+//           """
+//         }
+//       },
+//       test("disallow implicit mutable use") {
+//         var x = 1
+//         runLiftFailMsg(Messages.DeclarationNotAllowed) {
+//           """
+//           lazy val x = 123
+//           """
+//         }
+//       }
+//     )
+//   )
+// }

--- a/zio-direct/src/main/scala-3.x/zio/direct/core/Transformer.scala
+++ b/zio-direct/src/main/scala-3.x/zio/direct/core/Transformer.scala
@@ -65,7 +65,8 @@ class Transformer(inputQuotes: Quotes)
         Announce.section("Monadified Tries (No Changes)", "", fileShow)
     }
 
-    val output = ReconstructTree(instructions).fromIR(transformed)
+    val irt = IRT.Compute(transformed)(using instructions.typeUnion)
+    val output = ReconstructTree(instructions).fromIR(irt)
     if (instructions.info.showReconstructed)
       val showDetailsMode =
         instructions.info match {
@@ -78,8 +79,7 @@ class Transformer(inputQuotes: Quotes)
     if (instructions.info.showReconstructedTree)
       Announce.section("Reconstituted Code Raw", Format(Printer.TreeStructure.show(output)), fileShow)
 
-    val computedType = ComputeType.fromIR(transformed)(using instructions)
-
+    val computedType = irt.zpe
     val zioType = computedType.toZioType
 
     if (instructions.info.showComputedTypeDetail)

--- a/zio-direct/src/main/scala-3.x/zio/direct/core/Transformer.scala
+++ b/zio-direct/src/main/scala-3.x/zio/direct/core/Transformer.scala
@@ -16,6 +16,7 @@ import zio.direct.core.metaprog.Embedder._
 import zio.direct.core.norm.WithComputeType
 import zio.direct.core.norm.WithReconstructTree
 import zio.direct.core.norm.WithDecomposeTree
+import zio.direct.core.norm.WithResolver
 import zio.direct.core.util.ShowDetails
 import zio.direct.Internal.deferred
 import zio.direct.core.util.Announce
@@ -27,7 +28,8 @@ class Transformer(inputQuotes: Quotes)
     with WithReconstructTree
     with WithDecomposeTree
     with WithInterpolator
-    with WithZioType {
+    with WithZioType
+    with WithResolver {
 
   implicit val macroQuotes = inputQuotes
   import quotes.reflect._

--- a/zio-direct/src/main/scala-3.x/zio/direct/core/Transformer.scala
+++ b/zio-direct/src/main/scala-3.x/zio/direct/core/Transformer.scala
@@ -65,7 +65,7 @@ class Transformer(inputQuotes: Quotes)
         Announce.section("Monadified Tries (No Changes)", "", fileShow)
     }
 
-    val irt = IRT.Compute(transformed)(using instructions.typeUnion)
+    val irt = ComputeIRT(transformed)(using instructions.typeUnion)
     val output = ReconstructTree(instructions).fromIR(irt)
     if (instructions.info.showReconstructed)
       val showDetailsMode =

--- a/zio-direct/src/main/scala-3.x/zio/direct/core/Transformer.scala
+++ b/zio-direct/src/main/scala-3.x/zio/direct/core/Transformer.scala
@@ -71,10 +71,10 @@ class Transformer(inputQuotes: Quotes)
           case InfoBehavior.Verbose     => ShowDetails.Standard
           case _                        => ShowDetails.Compact
         }
-      Announce.section("Reconstituted Code", Format.Expr(output, Format.Mode.DottyColor(showDetailsMode)), fileShow)
+      Announce.section("Reconstituted Code", Format.Term(output, Format.Mode.DottyColor(showDetailsMode)), fileShow)
 
     if (instructions.info.showReconstructedTree)
-      Announce.section("Reconstituted Code Raw", Format(Printer.TreeStructure.show(output.asTerm)), fileShow)
+      Announce.section("Reconstituted Code Raw", Format(Printer.TreeStructure.show(output)), fileShow)
 
     val computedType = ComputeType.fromIR(transformed)(using instructions)
 
@@ -84,8 +84,8 @@ class Transformer(inputQuotes: Quotes)
       println(
         s"""-------------
         |Computed-Type: ${Format.TypeRepr(zioType)}
-        |Discovered-Type: ${Format.TypeRepr(output.asTerm.tpe)}
-        |Is Subtype: ${zioType <:< output.asTerm.tpe}
+        |Discovered-Type: ${Format.TypeRepr(output.tpe)}
+        |Is Subtype: ${zioType <:< output.tpe}
         |""".stripMargin
       )
 
@@ -94,7 +94,7 @@ class Transformer(inputQuotes: Quotes)
 
     // If there are any remaining run-calls in the tree then fail
     // TODO need to figure out a way to test this
-    Allowed.finalValidtyCheck(output, instructions)
+    Allowed.finalValidtyCheck(output.asExprOf[ZIO[?, ?, ?]], instructions)
 
     computedType.asTypeTuple match {
       case ('[r], '[e], '[a]) =>
@@ -107,7 +107,7 @@ class Transformer(inputQuotes: Quotes)
             case None =>
               report.info(computedTypeMsg)
           }
-        '{ deferred($output.asInstanceOf[ZIO[r, e, a]]) }
+        '{ deferred(${ output.asExpr }.asInstanceOf[ZIO[r, e, a]]) }
     }
   }
 }

--- a/zio-direct/src/main/scala-3.x/zio/direct/core/metaprog/Embedder.scala
+++ b/zio-direct/src/main/scala-3.x/zio/direct/core/metaprog/Embedder.scala
@@ -35,15 +35,15 @@ object Embedder {
       import quotes.reflect._
       term.tpe.asType match
         case '[t] =>
-          '{ zio.ZIO.succeed[t](${ term.asExprOf[t] }) } // .asInstanceOf[ZIO[Any, Nothing, t]]
+          '{ zio.ZIO.succeed[t](${ term.asExprOf[t] }) }.asTerm // .asInstanceOf[ZIO[Any, Nothing, t]]
 
     def True(using Quotes) =
       import quotes.reflect._
-      succeed(Expr(true).asTerm).asExprOf[zio.ZIO[Any, Nothing, Boolean]]
+      succeed(Expr(true).asTerm)
 
     def False(using Quotes) =
       import quotes.reflect._
-      succeed(Expr(false).asTerm).asExprOf[zio.ZIO[Any, Nothing, Boolean]]
+      succeed(Expr(false).asTerm)
   }
 
   private def findOwner(using Quotes)(owner: quotes.reflect.Symbol, skipSymbol: quotes.reflect.Symbol => Boolean): quotes.reflect.Symbol =

--- a/zio-direct/src/main/scala-3.x/zio/direct/core/metaprog/Embedder.scala
+++ b/zio-direct/src/main/scala-3.x/zio/direct/core/metaprog/Embedder.scala
@@ -25,27 +25,6 @@ object Embedder {
     // a |dotty.tools.dotc.core.CyclicReference error.
     findOwner(Symbol.spliceOwner, sym => sym.name == "macro")
 
-  object ZioApply {
-    // wrap the value in a ZIO.succeed. Note that widening here could have some serious consequences
-    // and make statements not many any sense of the term passed in represents a singleton-type
-    // e.g. Zio.Apply('{ 1 }) or a union of singleton types e.g. Zio.Apply('{ if (blah) 1 else 2 })
-    // (the latter is typed as `1 | 2`)
-    def succeed(using Quotes)(term: quotes.reflect.Term) =
-      // TODO widenByTermRef just in case?
-      import quotes.reflect._
-      term.tpe.asType match
-        case '[t] =>
-          '{ zio.ZIO.succeed[t](${ term.asExprOf[t] }) }.asTerm // .asInstanceOf[ZIO[Any, Nothing, t]]
-
-    def True(using Quotes) =
-      import quotes.reflect._
-      succeed(Expr(true).asTerm)
-
-    def False(using Quotes) =
-      import quotes.reflect._
-      succeed(Expr(false).asTerm)
-  }
-
   private def findOwner(using Quotes)(owner: quotes.reflect.Symbol, skipSymbol: quotes.reflect.Symbol => Boolean): quotes.reflect.Symbol =
     var topOwner = owner
     while (skipSymbol(topOwner)) topOwner = topOwner.owner

--- a/zio-direct/src/main/scala-3.x/zio/direct/core/metaprog/WithIR.scala
+++ b/zio-direct/src/main/scala-3.x/zio/direct/core/metaprog/WithIR.scala
@@ -16,36 +16,6 @@ trait WithIR {
   implicit val macroQuotes: Quotes
   import macroQuotes.reflect._
 
-  // object Foo {
-
-  //   protected sealed trait IRT
-  //   protected object IRT {
-  //     sealed trait Monadic extends IRT
-  //     sealed trait Leaf extends IRT
-
-  //     case class Monad(ir: IR.Monad) extends Monadic with Leaf
-  //     case class Pure(ir: IR.Pure) extends IRT with Leaf
-  //     case class Fail(ir: IR.Fail) extends Monadic
-
-  //     case class While(ir: IR.While)(cond: IRT, body: IRT) extends Monadic
-  //     case class ValDef(ir: IR.ValDef)(assignment: IRT, bodyUsingVal: IRT) extends Monadic
-  //     case class Unsafe(ir: IR.Unsafe)(body: IRT) extends Monadic
-  //     case class Try(ir: IR.Try)(tryBlock: IRT, cases: List[IRT.Match.CaseDef], resultType: TypeRepr, finallyBlock: Option[IRT]) extends Monadic
-  //     case class Foreach(ir: IR.Foreach)(list: IRT, listType: TypeRepr, elementSymbol: Symbol, body: IRT) extends Monadic
-  //     case class FlatMap(ir: IR.FlatMap)(monad: Monadic, valSymbol: Option[Symbol], body: IRT.Monadic) extends Monadic
-  //     case class Map(ir: IR.Map)(monad: Monadic, valSymbol: Option[Symbol], body: IRT.Pure) extends Monadic
-  //     case class Block(ir: IR.Block)(head: Statement, tail: Monadic) extends Monadic
-  //     case class Match(ir: IR.Match)(scrutinee: IRT, caseDefs: List[IRT.Match.CaseDef]) extends Monadic
-  //     case class If(ir: IR.If)(cond: IRT, ifTrue: IRT, ifFalse: IRT) extends Monadic
-  //     case class And(ir: IR.And)(left: IRT, right: IRT) extends Monadic
-  //     case class Or(ir: IR.Or)(left: IRT, right: IRT) extends Monadic
-  //     case class Parallel(ir: IR.Parallel)(originalExpr: Term, monads: List[(IRT.Monadic, Symbol)], body: IRT.Leaf) extends Monadic
-  //     object Match {
-  //       case class CaseDef(ir: IR.Match.CaseDef)(rhs: Monadic)
-  //     }
-  //   }
-  // }
-
   protected sealed trait IR
   protected object IR {
     sealed trait Monadic extends IR

--- a/zio-direct/src/main/scala-3.x/zio/direct/core/metaprog/WithIR.scala
+++ b/zio-direct/src/main/scala-3.x/zio/direct/core/metaprog/WithIR.scala
@@ -8,11 +8,44 @@ import zio.ZIO
 import scala.tools.nsc.PipelineMain.Pipeline
 import zio.direct.core.util.Unsupported
 import zio.direct.core.util.Messages
+import zio.direct.core.util.WithFormat
 import zio.direct.core.metaprog.Extractors.BlockN
 
 trait WithIR {
+  self: WithZioType =>
+
   implicit val macroQuotes: Quotes
   import macroQuotes.reflect._
+
+  // object Foo {
+
+  //   protected sealed trait IRT
+  //   protected object IRT {
+  //     sealed trait Monadic extends IRT
+  //     sealed trait Leaf extends IRT
+
+  //     case class Monad(ir: IR.Monad) extends Monadic with Leaf
+  //     case class Pure(ir: IR.Pure) extends IRT with Leaf
+  //     case class Fail(ir: IR.Fail) extends Monadic
+
+  //     case class While(ir: IR.While)(cond: IRT, body: IRT) extends Monadic
+  //     case class ValDef(ir: IR.ValDef)(assignment: IRT, bodyUsingVal: IRT) extends Monadic
+  //     case class Unsafe(ir: IR.Unsafe)(body: IRT) extends Monadic
+  //     case class Try(ir: IR.Try)(tryBlock: IRT, cases: List[IRT.Match.CaseDef], resultType: TypeRepr, finallyBlock: Option[IRT]) extends Monadic
+  //     case class Foreach(ir: IR.Foreach)(list: IRT, listType: TypeRepr, elementSymbol: Symbol, body: IRT) extends Monadic
+  //     case class FlatMap(ir: IR.FlatMap)(monad: Monadic, valSymbol: Option[Symbol], body: IRT.Monadic) extends Monadic
+  //     case class Map(ir: IR.Map)(monad: Monadic, valSymbol: Option[Symbol], body: IRT.Pure) extends Monadic
+  //     case class Block(ir: IR.Block)(head: Statement, tail: Monadic) extends Monadic
+  //     case class Match(ir: IR.Match)(scrutinee: IRT, caseDefs: List[IRT.Match.CaseDef]) extends Monadic
+  //     case class If(ir: IR.If)(cond: IRT, ifTrue: IRT, ifFalse: IRT) extends Monadic
+  //     case class And(ir: IR.And)(left: IRT, right: IRT) extends Monadic
+  //     case class Or(ir: IR.Or)(left: IRT, right: IRT) extends Monadic
+  //     case class Parallel(ir: IR.Parallel)(originalExpr: Term, monads: List[(IRT.Monadic, Symbol)], body: IRT.Leaf) extends Monadic
+  //     object Match {
+  //       case class CaseDef(ir: IR.Match.CaseDef)(rhs: Monadic)
+  //     }
+  //   }
+  // }
 
   protected sealed trait IR
   protected object IR {

--- a/zio-direct/src/main/scala-3.x/zio/direct/core/metaprog/WithIR.scala
+++ b/zio-direct/src/main/scala-3.x/zio/direct/core/metaprog/WithIR.scala
@@ -8,7 +8,6 @@ import zio.ZIO
 import scala.tools.nsc.PipelineMain.Pipeline
 import zio.direct.core.util.Unsupported
 import zio.direct.core.util.Messages
-import zio.direct.core.util.WithFormat
 import zio.direct.core.metaprog.Extractors.BlockN
 
 trait WithIR {

--- a/zio-direct/src/main/scala-3.x/zio/direct/core/metaprog/WithIR.scala
+++ b/zio-direct/src/main/scala-3.x/zio/direct/core/metaprog/WithIR.scala
@@ -16,6 +16,7 @@ trait WithIR {
   implicit val macroQuotes: Quotes
   import macroQuotes.reflect._
 
+  /* =============================================== IR =============================================== */
   protected sealed trait IR
   protected object IR {
     sealed trait Monadic extends IR
@@ -26,17 +27,11 @@ trait WithIR {
     // TODO It's possible to do `throw run(function)` so need to support IR
     // being passed into a throw.
     case class Fail(error: IR) extends Monadic
-
     case class While(cond: IR, body: IR) extends Monadic
-
     case class ValDef(originalStmt: macroQuotes.reflect.Block, symbol: Symbol, assignment: IR, bodyUsingVal: IR) extends Monadic
-
     case class Unsafe(body: IR) extends Monadic
-
     case class Try(tryBlock: IR, cases: List[IR.Match.CaseDef], resultType: TypeRepr, finallyBlock: Option[IR]) extends Monadic
-
     case class Foreach(list: IR, listType: TypeRepr, elementSymbol: Symbol, body: IR) extends Monadic
-
     case class FlatMap(monad: Monadic, valSymbol: Option[Symbol], body: IR.Monadic) extends Monadic
     object FlatMap {
       def apply(monad: IR.Monadic, valSymbol: Symbol, body: IR.Monadic) =
@@ -47,7 +42,6 @@ trait WithIR {
       def apply(monad: Monadic, valSymbol: Symbol, body: IR.Pure) =
         new Map(monad, Some(valSymbol), body)
     }
-
     class Monad private (val code: Term, val source: Monad.Source) extends Monadic with Leaf {
       private val id = Monad.Id(code)
       override def equals(other: Any): Boolean =
@@ -57,12 +51,8 @@ trait WithIR {
         }
     }
     object Monad {
-      def apply(code: Term, source: Monad.Source = Monad.Source.Pipeline) =
-        new Monad(code, source)
-
-      def unapply(value: Monad) =
-        Some(value.code)
-
+      def apply(code: Term, source: Monad.Source = Monad.Source.Pipeline) = new Monad(code, source)
+      def unapply(value: Monad) = Some(value.code)
       sealed trait Source
       case object Source {
         case object Pipeline extends Source
@@ -70,34 +60,60 @@ trait WithIR {
         case object PrevDefer extends Source
         case object IgnoreCall extends Source
       }
-
       private case class Id(code: Term)
     }
-
-    // TODO Function to collapse inner blocks into one block because you can have Block(term, Block(term, Block(monad)))
     case class Block(head: Statement, tail: Monadic) extends Monadic
-
-    // TODO scrutinee can be monadic or Match output can be monadic, how about both?
-    // scrutinee can be Monadic or Pure. Not using union type so that perhaps can backward-compat with Scala 2
     case class Match(scrutinee: IR, caseDefs: List[IR.Match.CaseDef]) extends Monadic
     object Match {
       case class CaseDef(pattern: Tree, guard: Option[Term], rhs: Monadic)
     }
-
-    // Since we ultimately transform If statements into Task[Boolean] segments, they are monadic
-    // TODO during transformation, decided cases based on if ifTrue/ifFalse is monadic or not
     case class If(cond: IR, ifTrue: IR, ifFalse: IR) extends Monadic
     case class Pure(code: Term) extends IR with Leaf
-
     // Note that And/Or expressions ultimately need to have both of their sides lifted,
     // if one either side is not actually a monad we need to lift it. Therefore
     // we can treat And/Or as monadic (i.e. return the from the main Transform)
     case class And(left: IR, right: IR) extends Monadic
     case class Or(left: IR, right: IR) extends Monadic
-
     case class Parallel(originalExpr: Term, monads: List[(IR.Monadic, Symbol)], body: IR.Leaf) extends Monadic
   }
 
+  /* =============================================== Typed IR (IRT) =============================================== */
+  protected sealed trait IRT {
+    def zpe: ZioType
+  }
+  protected object IRT {
+    sealed trait Monadic extends IRT
+    sealed trait Leaf extends IRT
+    case class Fail(error: IRT)(val zpe: ZioType) extends Monadic
+    case class While(cond: IRT, body: IRT)(val zpe: ZioType) extends Monadic
+    case class ValDef(originalStmt: macroQuotes.reflect.Block, symbol: Symbol, assignment: IRT, bodyUsingVal: IRT)(val zpe: ZioType) extends Monadic
+    case class Unsafe(body: IRT)(val zpe: ZioType) extends Monadic
+    case class Try(tryBlock: IRT, cases: List[IRT.Match.CaseDef], resultType: TypeRepr, finallyBlock: Option[IRT])(val zpe: ZioType) extends Monadic
+    case class Foreach(list: IRT, listType: TypeRepr, elementSymbol: Symbol, body: IRT)(val zpe: ZioType) extends Monadic
+    case class FlatMap(monad: Monadic, valSymbol: Option[Symbol], body: IRT.Monadic)(val zpe: ZioType) extends Monadic
+    case class Map(monad: Monadic, valSymbol: Option[Symbol], body: IRT.Pure)(val zpe: ZioType) extends Monadic
+    case class Monad(code: Term, source: IR.Monad.Source)(val zpe: ZioType) extends Monadic with Leaf
+    object Monad {
+      def fromZioValue(zv: ZioValue) =
+        apply(zv.term, IR.Monad.Source.Pipeline)(zv.zpe)
+    }
+
+    case class Block(head: Statement, tail: Monadic)(val zpe: ZioType) extends Monadic
+    case class Match(scrutinee: IRT, caseDefs: List[IRT.Match.CaseDef])(val zpe: ZioType) extends Monadic
+    case class If(cond: IRT, ifTrue: IRT, ifFalse: IRT)(val zpe: ZioType) extends Monadic
+    case class Pure(code: Term)(val zpe: ZioType) extends IRT with Leaf
+    object Pure {
+      def fromTerm(term: Term) = Pure(term)(ZioType.fromPure(term))
+    }
+    case class And(left: IRT, right: IRT)(val zpe: ZioType) extends Monadic
+    case class Or(left: IRT, right: IRT)(val zpe: ZioType) extends Monadic
+    case class Parallel(originalExpr: Term, monads: List[(IRT.Monadic, Symbol)], body: IRT.Leaf)(val zpe: ZioType) extends Monadic
+    object Match {
+      case class CaseDef(pattern: Tree, guard: Option[Term], rhs: Monadic)(val zpe: ZioType)
+    }
+  }
+
+  /* =============================================== Various Transforms =============================================== */
   /**
    * Wrap the IR.Pures/IR.Maps in the body of IR.Unsafe elements with ZIO.attempt.
    * This is largely for the sake of tries working as expected, for example.

--- a/zio-direct/src/main/scala-3.x/zio/direct/core/metaprog/WithPrintIR.scala
+++ b/zio-direct/src/main/scala-3.x/zio/direct/core/metaprog/WithPrintIR.scala
@@ -5,9 +5,10 @@ import pprint._
 import fansi.Str
 import zio.direct.core.util.Format
 import zio.direct.core.norm.WithComputeType
+import zio.direct.core.util.WithInterpolator
 
 trait WithPrintIR {
-  self: WithIR with WithZioType with WithComputeType =>
+  self: WithIR with WithZioType with WithComputeType with WithInterpolator =>
 
   implicit val macroQuotes: Quotes
   import macroQuotes.reflect

--- a/zio-direct/src/main/scala-3.x/zio/direct/core/metaprog/WithPrintIR.scala
+++ b/zio-direct/src/main/scala-3.x/zio/direct/core/metaprog/WithPrintIR.scala
@@ -8,7 +8,7 @@ import zio.direct.core.norm.WithComputeType
 import zio.direct.core.util.WithInterpolator
 
 trait WithPrintIR {
-  self: WithIR with WithZioType with WithComputeType with WithInterpolator =>
+  self: WithIR with WithZioType =>
 
   implicit val macroQuotes: Quotes
   import macroQuotes.reflect

--- a/zio-direct/src/main/scala-3.x/zio/direct/core/metaprog/WithZioType.scala
+++ b/zio-direct/src/main/scala-3.x/zio/direct/core/metaprog/WithZioType.scala
@@ -20,6 +20,13 @@ trait WithZioType {
     def transformA(f: TypeRepr => TypeRepr) =
       ZioType(r, e, f(a))
 
+    def value = a
+    def monad = toZioType
+
+    def valueType = value.asType
+    def monadType = monad.asType
+    def monadAndValueTypes = (valueType, monadType)
+
     def asTypeTuple = (r.asType, e.asType, a.asType)
 
     def toZioType: TypeRepr =

--- a/zio-direct/src/main/scala-3.x/zio/direct/core/metaprog/WithZioType.scala
+++ b/zio-direct/src/main/scala-3.x/zio/direct/core/metaprog/WithZioType.scala
@@ -10,9 +10,14 @@ trait WithZioType {
   implicit val macroQuotes: Quotes
   import macroQuotes.reflect._
 
-  case class ZioValue(term: Term, zpe: ZioType)
+  class ZioValue(val term: Term, val zpe: ZioType) {
+    def expr: Expr[_] = term.asExpr
+  }
+
   // TODO when we support non-zio values, will need to have one of these for each supported type
   object ZioValue {
+    def apply(term: Term, zpe: ZioType) = new ZioValue(term, zpe)
+    def apply(expr: Expr[_], zpe: ZioType) = new ZioValue(expr.asTerm, zpe)
 
     def apply(zpe: ZioType) = new ZioValueMaker(zpe)
 

--- a/zio-direct/src/main/scala-3.x/zio/direct/core/metaprog/WithZioType.scala
+++ b/zio-direct/src/main/scala-3.x/zio/direct/core/metaprog/WithZioType.scala
@@ -14,6 +14,13 @@ trait WithZioType {
     def expr: Expr[_] = term.asExpr
   }
 
+  implicit class TermOps(term: Term) {
+    def toZioValue(zpe: ZioType) = ZioValue(term, zpe)
+  }
+  implicit class ExprOps(expr: Expr[_]) {
+    def toZioValue(zpe: ZioType) = ZioValue(expr, zpe)
+  }
+
   // TODO when we support non-zio values, will need to have one of these for each supported type
   object ZioValue {
     def apply(term: Term, zpe: ZioType) = new ZioValue(term, zpe)

--- a/zio-direct/src/main/scala-3.x/zio/direct/core/metaprog/WithZioType.scala
+++ b/zio-direct/src/main/scala-3.x/zio/direct/core/metaprog/WithZioType.scala
@@ -78,6 +78,8 @@ trait WithZioType {
         ZioType.orN(as)
       )
 
+    def Unit = fromPure('{ () }.asTerm)
+
     def fromZIO(zio: Term) =
       zio.tpe.asType match
         case '[ZIO[r, e, a]] =>

--- a/zio-direct/src/main/scala-3.x/zio/direct/core/norm/WithComputeType.scala
+++ b/zio-direct/src/main/scala-3.x/zio/direct/core/norm/WithComputeType.scala
@@ -20,7 +20,7 @@ trait WithComputeType {
   import macroQuotes.reflect._
 
   protected sealed trait IRT {
-    def tpe: ZioType
+    def zpe: ZioType
     def ir: IR
   }
   protected object IRT {
@@ -35,6 +35,11 @@ trait WithComputeType {
     case class FlatMap(monad: Monadic, valSymbol: Option[Symbol], body: IRT.Monadic)(val zpe: ZioType) extends Monadic
     case class Map(monad: Monadic, valSymbol: Option[Symbol], body: IRT.Pure)(val zpe: ZioType) extends Monadic
     case class Monad(code: Term, source: IR.Monad.Source)(val zpe: ZioType) extends Monadic with Leaf
+    object Monad {
+      def fromZioValue(zv: ZioValue) =
+        apply(zv.term, IR.Monad.Source.Pipeline)(zv.zpe)
+    }
+
     case class Block(head: Statement, tail: Monadic)(val zpe: ZioType) extends Monadic
     case class Match(scrutinee: IRT, caseDefs: List[IRT.Match.CaseDef])(val zpe: ZioType) extends Monadic
     case class If(cond: IRT, ifTrue: IRT, ifFalse: IRT)(val zpe: ZioType) extends Monadic

--- a/zio-direct/src/main/scala-3.x/zio/direct/core/norm/WithComputeType.scala
+++ b/zio-direct/src/main/scala-3.x/zio/direct/core/norm/WithComputeType.scala
@@ -19,132 +19,252 @@ trait WithComputeType {
   implicit val macroQuotes: Quotes
   import macroQuotes.reflect._
 
-  object ComputeType {
-    def fromIR(ir: IR)(implicit instructions: Instructions): ZioType =
-      new ComputeType(instructions).apply(ir)
+  protected sealed trait IRT {
+    def tpe: ZioType
+    def ir: IR
   }
+  protected object IRT {
+    sealed trait Monadic extends IRT
+    sealed trait Leaf extends IRT
+    case class Fail(error: IRT)(val zpe: ZioType) extends Monadic
+    case class While(cond: IRT, body: IRT)(val zpe: ZioType) extends Monadic
+    case class ValDef(originalStmt: macroQuotes.reflect.Block, symbol: Symbol, assignment: IRT, bodyUsingVal: IRT)(val zpe: ZioType) extends Monadic
+    case class Unsafe(body: IRT)(val zpe: ZioType) extends Monadic
+    case class Try(tryBlock: IRT, cases: List[IRT.Match.CaseDef], resultType: TypeRepr, finallyBlock: Option[IRT])(val zpe: ZioType) extends Monadic
+    case class Foreach(list: IRT, listType: TypeRepr, elementSymbol: Symbol, body: IRT)(val zpe: ZioType) extends Monadic
+    case class FlatMap(monad: Monadic, valSymbol: Option[Symbol], body: IRT.Monadic)(val zpe: ZioType) extends Monadic
+    case class Map(monad: Monadic, valSymbol: Option[Symbol], body: IRT.Pure)(val zpe: ZioType) extends Monadic
+    case class Monad(code: Term, source: IR.Monad.Source)(val zpe: ZioType) extends Monadic with Leaf
+    case class Block(head: Statement, tail: Monadic)(val zpe: ZioType) extends Monadic
+    case class Match(scrutinee: IRT, caseDefs: List[IRT.Match.CaseDef])(val zpe: ZioType) extends Monadic
+    case class If(cond: IRT, ifTrue: IRT, ifFalse: IRT)(val zpe: ZioType) extends Monadic
+    case class Pure(code: Term)(val zpe: ZioType) extends IRT with Leaf
+    object Pure {
+      def fromTerm(term: Term) = Pure(term)(ZioType.fromPure(term))
+    }
+    case class And(left: IRT, right: IRT)(val zpe: ZioType) extends Monadic
+    case class Or(left: IRT, right: IRT)(val zpe: ZioType) extends Monadic
+    case class Parallel(originalExpr: Term, monads: List[(IRT.Monadic, Symbol)], body: IRT.Leaf)(val zpe: ZioType) extends Monadic
+    object Match {
+      case class CaseDef(pattern: Tree, guard: Option[Term], rhs: Monadic)(val zpe: ZioType)
+    }
 
-  class ComputeType private (instructions: Instructions) {
-    implicit val tu: TypeUnion = instructions.typeUnion
+    object Compute {
+      private def applyCaseDef(ir: IR.Match.CaseDef)(implicit typeUnion: TypeUnion): IRT.Match.CaseDef =
+        val rhsIRT = apply(ir.rhs)
+        IRT.Match.CaseDef(ir.pattern, ir.guard, rhsIRT)(rhsIRT.tpe)
 
-    def apply(ir: IR): ZioType =
-      ir match {
-        case ir @ IR.Pure(code) =>
-          ZioType.fromPure(code)
+      // TODO should introduce IR/IRT.CaseDefs as a separate module that can hold a type
+      //      so that this doesn't need to be recomputed
+      def applyCaseDefs(caseDefs: List[IRT.Match.CaseDef])(implicit typeUnion: TypeUnion) =
+        ZioType.composeN(caseDefs.map(_.zpe)).transformA(_.widen)
 
-        case ir @ IR.FlatMap(monad, valSymbol, body) =>
-          apply(monad).flatMappedWith(apply(body))
+      def apply(ir: IR.Monadic)(implicit typeUnion: TypeUnion): IRT.Monadic =
+        ir match
+          case ir: IR.Fail     => apply(ir)
+          case ir: IR.While    => apply(ir)
+          case ir: IR.ValDef   => apply(ir)
+          case ir: IR.Unsafe   => apply(ir)
+          case ir: IR.Try      => apply(ir)
+          case ir: IR.Foreach  => apply(ir)
+          case ir: IR.FlatMap  => apply(ir)
+          case ir: IR.Map      => apply(ir)
+          case ir: IR.Monad    => apply(ir)
+          case ir: IR.Block    => apply(ir)
+          case ir: IR.Match    => apply(ir)
+          case ir: IR.If       => apply(ir)
+          case ir: IR.And      => apply(ir)
+          case ir: IR.Or       => apply(ir)
+          case ir: IR.Parallel => apply(ir)
 
-        // Eventually a ValDef will be turned into a flatMap so if we still have one,
-        // the type-computation essentially is the same as the one for the flatMap
-        //   val symbol = assignment
-        //   bodyUsingVal
-        // Basically becomes:
-        //   assignment.flatMap { symbol =>
-        //     bodyUsingVal
-        //   }
-        // Theis essentially means that `assignment` is the monad-equivalent
-        // of flatMap and the bodyUsingVal is the body-equivalent.
-        case ir @ IR.ValDef(_, symbol, assignment, bodyUsingVal) =>
-          apply(assignment).flatMappedWith(apply(bodyUsingVal))
+      def apply(ir: IR.Leaf)(implicit typeUnion: TypeUnion): IRT.Leaf =
+        ir match
+          case ir: IR.Monad => apply(ir)
+          case ir: IR.Pure  => apply(ir)
 
-        case ir @ IR.Map(monad, valSymbol, IR.Pure(term)) =>
-          apply(monad).mappedWith(term)
+      def apply(ir: IR)(implicit typeUnion: TypeUnion): IRT =
+        ir match
+          case ir: IR.Monadic => apply(ir)
+          case ir: IR.Leaf    => apply(ir)
 
-        case ir @ IR.Monad(code) =>
-          ZioType.fromZIO(code)
+      def apply(ir: IR.Monad)(implicit typeUnion: TypeUnion): IRT.Monad =
+        IRT.Monad(ir.code, ir.source)(ZioType.fromZIO(ir.code))
 
-        case ir @ IR.Block(head, tail) =>
-          apply(tail)
+      def apply(ir: IR.Pure)(implicit typeUnion: TypeUnion): IRT.Pure =
+        IRT.Pure(ir.code)(ZioType.fromPure(ir.code))
 
-        case ir @ IR.Fail(error) =>
-          // The error type often is a single expression e.g. someFunctionThatThrowsError()
-          // so we need to widen it into the underlying type
-          val bodyError = apply(error)
-          ZioType(bodyError.r, bodyError.a.widenTermRefByName, TypeRepr.of[Nothing])
+      def apply(ir: IR.Fail)(implicit typeUnion: TypeUnion): IRT.Fail =
+        ir match
+          case IR.Fail(error) =>
+            // The error type often is a single expression e.g. someFunctionThatThrowsError()
+            // so we need to widen it into the underlying type
+            val bodyError = apply(error)
+            val tpe = ZioType(bodyError.tpe.r, bodyError.tpe.a.widenTermRefByName, TypeRepr.of[Nothing])
+            IRT.Fail(bodyError)(tpe)
 
-        // Things inside Unsafe blocks that are not inside runs will be wrapepd into ZIO.attempt
-        // which will make their lower-bound Throwable in the MonadifyTries phase.
-        // Do not need to do that manually here with the `e` type though.
-        case ir @ IR.Unsafe(body) =>
-          apply(body)
+      def apply(ir: IR.While)(implicit typeUnion: TypeUnion): IRT.While =
+        ir match
+          case IR.While(cond, body) =>
+            val condIRT = apply(cond)
+            val bodyIRT = apply(body)
+            val tpe = condIRT.tpe.flatMappedWith(bodyIRT.tpe).mappedWithType(TypeRepr.of[Unit])
+            IRT.While(condIRT, bodyIRT)(tpe)
 
-        case ir @ IR.Match(scrutinee, caseDefs) =>
-          // Ultimately the scrutinee will be used if it is pure or lifted, either way we can
-          // treat it as a value that will be flatMapped (or Mapped) against the caseDef values.
-          val scrutineeType = apply(scrutinee)
-          // NOTE: We can possibly do the same thing as IR.Try and pass through the Match result tpe, then
-          // then use that to figure out what the type should be
-          val caseDefTypes = caseDefs.map(caseDef => apply(caseDef.rhs))
-          val caseDefTotalType = ZioType.composeN(caseDefTypes)(instructions.typeUnion)
-          scrutineeType.flatMappedWith(caseDefTotalType)
+      def apply(ir: IR.ValDef)(implicit typeUnion: TypeUnion): IRT.ValDef =
+        ir match
+          case IR.ValDef(originalStmt, symbol, assignment, bodyUsingVal) =>
+            // Eventually a ValDef will be turned into a flatMap so if we still have one,
+            // the type-computation essentially is the same as the one for the flatMap
+            //   val symbol = assignment
+            //   bodyUsingVal
+            // Basically becomes:
+            //   assignment.flatMap { symbol =>
+            //     bodyUsingVal
+            //   }
+            // Theis essentially means that `assignment` is the monad-equivalent
+            // of flatMap and the bodyUsingVal is the body-equivalent.
+            val assignmentIRT = apply(assignment)
+            val bodyIRT = apply(bodyUsingVal)
+            val tpe = assignmentIRT.tpe.flatMappedWith(bodyIRT.tpe)
+            IRT.ValDef(ir.originalStmt, ir.symbol, assignmentIRT, bodyIRT)(tpe)
 
-        case ir @ IR.If(cond, ifTrue, ifFalse) =>
-          val condType = apply(cond)
-          val expressionType = ZioType.compose(apply(ifTrue), apply(ifFalse))
-          condType.flatMappedWith(expressionType)
+      def apply(ir: IR.Unsafe)(implicit typeUnion: TypeUnion): IRT.Unsafe =
+        ir match
+          case IR.Unsafe(body) =>
+            // Things inside Unsafe blocks that are not inside runs will be wrapepd into ZIO.attempt
+            // which will make their lower-bound Throwable in the MonadifyTries phase.
+            // Do not need to do that manually here with the `e` type though.
+            val unsafeIRT = apply(body)
+            val tpe = unsafeIRT.tpe
+            IRT.Unsafe(unsafeIRT)(tpe)
 
-        case ir @ IR.And(left, right) =>
-          ZioType.compose(apply(left), apply(right))
+      def apply(ir: IR.Try)(implicit typeUnion: TypeUnion): IRT.Try =
+        ir match
+          case IR.Try(tryBlock, caseDefs, resultType, finallyBlock) =>
+            val tryBlockIRT = apply(tryBlock)
+            val caseDefIRTs = caseDefs.map(applyCaseDef(_))
 
-        case ir @ IR.Or(left, right) =>
-          ZioType.compose(apply(left), apply(right))
+            // We get better results by doing into the case-defs and computing the union-type of them
+            // than we do by getting the information from outputType because outputType is limited
+            // by Scala's ability to understand the try-catch. For example, if we infer from outputType,
+            // the error-type will never be more concrete that `Throwable`.
+            // (Note, widen the error type because even if it's a concrete int type
+            // e.g. `catch { case e: Throwable => 111 }` we don't necessarily know
+            // that this error will actually happen therefore it's not sensical to make it a singleton type)
+            val caseDefType = applyCaseDefs(caseDefIRTs)
 
-        case ir @ IR.Try(tryBlock, caseDefs, outputType, finallyBlock) =>
-          val tryBlockType = apply(tryBlock)
-          // We get better results by doing into the case-defs and computing the union-type of them
-          // than we do by getting the information from outputType because outputType is limited
-          // by Scala's ability to understand the try-catch. For example, if we infer from outputType,
-          // the error-type will never be more concrete that `Throwable`.
-          // (Note, widen the error type because even if it's a concrete int type
-          // e.g. `catch { case e: Throwable => 111 }` we don't necessarily know
-          // that this error will actually happen therefore it's not sensical to make it a singleton type)
-          val caseDefType =
-            ZioType.composeN(caseDefs.map(caseDef => apply(caseDef.rhs)))(instructions.typeUnion).transformA(_.widen)
-          // Could also compute from outputType but this has worse results, see comment above.
-          // val caseDefType =
-          //   outputType.asType match
-          //     case '[ZIO[r, e, a]] => ZioType(TypeRepr.of[r].widen, TypeRepr.of[e].widen, TypeRepr.of[a].widen)
-          //     case '[t]            => ZioType(TypeRepr.of[Any].widen, TypeRepr.of[Throwable].widen, TypeRepr.of[t].widen)
-          tryBlockType.flatMappedWith(caseDefType)
+            // Could also apply from outputType but this has worse results, see comment above.
+            // val caseDefType =
+            //   outputType.asType match
+            //     case '[ZIO[r, e, a]] => ZioType(TypeRepr.of[r].widen, TypeRepr.of[e].widen, TypeRepr.of[a].widen)
+            //     case '[t]            => ZioType(TypeRepr.of[Any].widen, TypeRepr.of[Throwable].widen, TypeRepr.of[t].widen)
+            val tpe = tryBlockIRT.tpe.flatMappedWith(caseDefType)
+            val finallyBlockIRT = finallyBlock.map(apply(_))
+            IRT.Try(tryBlockIRT, caseDefIRTs, ir.resultType, finallyBlockIRT)(tpe)
 
-        case ir @ IR.While(cond, body) =>
-          val condTpe = apply(cond)
-          val bodyTpe = apply(body)
-          condTpe.flatMappedWith(bodyTpe).mappedWithType(TypeRepr.of[Unit])
+      def apply(ir: IR.Foreach)(implicit typeUnion: TypeUnion): IRT.Foreach =
+        ir match
+          case IR.Foreach(monad, _, _, body) =>
+            val monadIRT = apply(monad)
+            val bodyIRT = apply(body)
+            val tpe =
+              ZioType.fromMulti(
+                List(bodyIRT.tpe.r, monadIRT.tpe.r),
+                List(bodyIRT.tpe.e, monadIRT.tpe.e),
+                List(TypeRepr.of[Unit])
+              )
+            IRT.Foreach(monadIRT, ir.listType, ir.elementSymbol, bodyIRT)(tpe)
 
-        // TODO Follow the same pattern as Scala2 zio-direct and specialize the fromMulti method
-        // it is actually better that way because things can be widened etc... the only two
-        // remaining places where ZioType can be created (i.e. the fromPure and fromZIO methods)
-        case ir @ IR.Foreach(monad, _, _, body) =>
-          val monadType = apply(monad)
-          val bodyType = apply(body)
-          ZioType.fromMulti(
-            List(bodyType.r, monadType.r),
-            List(bodyType.e, monadType.e),
-            List(TypeRepr.of[Unit])
-          )(using instructions.typeUnion)
+      def apply(ir: IR.FlatMap)(implicit typeUnion: TypeUnion): IRT.FlatMap =
+        ir match
+          case IR.FlatMap(monad, valSymbol, body) =>
+            val monadIRT = apply(monad)
+            val bodyIRT = apply(body)
+            val tpe = monadIRT.tpe.flatMappedWith(bodyIRT.tpe)
+            IRT.FlatMap(monadIRT, ir.valSymbol, bodyIRT)(tpe)
 
-        case ir @ IR.Parallel(_, monadics, body) =>
-          val monadTypes =
-            monadics.map((monadic, _) => apply(monadic))
+      def apply(ir: IR.Map)(implicit typeUnion: TypeUnion): IRT.Map =
+        ir match
+          case IR.Map(monad, valSymbol, body @ IR.Pure(term)) =>
+            val monadIRT = apply(monad)
+            val tpe = monadIRT.tpe.mappedWith(term)
+            IRT.Map(monadIRT, ir.valSymbol, IRT.Pure.fromTerm(term))(tpe)
 
-          // a IR.Leaf will either be a IR.Pure or an IR.Monad, both already have cases here
-          val bodyType = apply(body)
+      def apply(ir: IR.Block)(implicit typeUnion: TypeUnion): IRT.Block =
+        ir match
+          case IR.Block(head, tail) =>
+            val tailIRT = apply(tail)
+            IRT.Block(head, tailIRT)(tailIRT.tpe)
 
-          // For some arbitrary structure that contains monads e.g:
-          //   ((foo:ZIO[ConfA,ExA,A]).run, (bar:ZIO[ConfB,ExB,B]).run)
-          // This will turn into something like:
-          //   ZIO.collectAll(foo, bar).map(col => {val iter = col.iter; (iter.next, iter.next)}) which has the type
-          // That means that the output signature will be a ZIO of the following:
-          //   R-Parameter: ConfA & ConfB, E-Parameter: ExA | ExB, A-Parameter: (A, B)
-          // In some cases the above function will be a flatMap and wrapped into a ZIO.attempt or ZIO.succeed
-          //   so we include the body-type error and environment just in case
-          ZioType.fromMulti(
-            bodyType.r +: monadTypes.map(_.r),
-            bodyType.e +: monadTypes.map(_.e),
-            List(bodyType.a)
-          )(using instructions.typeUnion)
-      }
+      def apply(ir: IR.Match)(implicit typeUnion: TypeUnion): IRT.Match =
+        ir match
+          case IR.Match(scrutinee, caseDefs) =>
+            // Ultimately the scrutinee will be used if it is pure or lifted, either way we can
+            // treat it as a value that will be flatMapped (or Mapped) against the caseDef values.
+            val scrutineeIRT = apply(scrutinee)
+            // NOTE: We can possibly do the same thing as IR.Try and pass through the Match result tpe, then
+            // then use that to figure out what the type should be
+            val caseDefIRTs = caseDefs.map(applyCaseDef(_))
+            val caseDefType = ZioType.composeN(caseDefIRTs.map(_.zpe)).transformA(_.widen)
+            val tpe = scrutineeIRT.tpe.flatMappedWith(caseDefType)
+            IRT.Match(scrutineeIRT, caseDefIRTs)(tpe)
+
+      def apply(ir: IR.Parallel)(implicit typeUnion: TypeUnion): IRT.Parallel =
+        ir match
+          case IR.Parallel(_, monadics, body) =>
+            val monadicsIRTs =
+              monadics.map((monadic, sym) => (apply(monadic), sym))
+
+            // a IR.Leaf will either be a IR.Pure or an IR.Monad, both already have cases here
+            val bodyIRT = apply(body).asInstanceOf[IRT.Leaf]
+
+            // For some arbitrary structure that contains monads e.g:
+            //   ((foo:ZIO[ConfA,ExA,A]).run, (bar:ZIO[ConfB,ExB,B]).run)
+            // This will turn into something like:
+            //   ZIO.collectAll(foo, bar).map(col => {val iter = col.iter; (iter.next, iter.next)}) which has the type
+            // That means that the output signature will be a ZIO of the following:
+            //   R-Parameter: ConfA & ConfB, E-Parameter: ExA | ExB, A-Parameter: (A, B)
+            // In some cases the above function will be a flatMap and wrapped into a ZIO.attempt or ZIO.succeed
+            //   so we include the body-type error and environment just in case
+            val tpe =
+              ZioType.fromMulti(
+                bodyIRT.tpe.r +: monadicsIRTs.map { (mon, _) => mon.tpe.r },
+                bodyIRT.tpe.e +: monadicsIRTs.map { (mon, _) => mon.tpe.e },
+                List(bodyIRT.tpe.a)
+              )
+
+            IRT.Parallel(ir.originalExpr, monadicsIRTs, bodyIRT)(tpe)
+
+      def apply(ir: IR.If)(implicit typeUnion: TypeUnion): IRT.If =
+        ir match
+          case IR.If(cond, ifTrue, ifFalse) =>
+            val condIRT = apply(cond)
+            val ifTrueIRT = apply(ifTrue)
+            val ifFalseIRT = apply(ifFalse)
+            // Something like this: if (a) then b else c
+            // Becomes something like this: a.flatMap(av => if (av) b.flatMap(...) else c.flatMap(...))
+            // So the output type is the a.flatMappedWith(b compose c)
+            val tpe =
+              condIRT.tpe.flatMappedWith(
+                ZioType.compose(ifTrueIRT.tpe, ifFalseIRT.tpe)
+              )
+            IRT.If(condIRT, ifTrueIRT, ifFalseIRT)(tpe)
+
+      def apply(ir: IR.And)(implicit typeUnion: TypeUnion): IRT.And =
+        ir match
+          case IR.And(left, right) =>
+            val leftIRT = apply(left)
+            val rightIRT = apply(right)
+            val tpe = ZioType.compose(leftIRT.tpe, rightIRT.tpe)
+            IRT.And(leftIRT, rightIRT)(tpe)
+
+      def apply(ir: IR.Or)(implicit typeUnion: TypeUnion): IRT.Or =
+        ir match
+          case IR.Or(left, right) =>
+            val leftIRT = apply(left)
+            val rightIRT = apply(right)
+            val tpe = ZioType.compose(leftIRT.tpe, rightIRT.tpe)
+            IRT.Or(leftIRT, rightIRT)(tpe)
+    }
   }
 }

--- a/zio-direct/src/main/scala-3.x/zio/direct/core/norm/WithComputeType.scala
+++ b/zio-direct/src/main/scala-3.x/zio/direct/core/norm/WithComputeType.scala
@@ -19,256 +19,221 @@ trait WithComputeType {
   implicit val macroQuotes: Quotes
   import macroQuotes.reflect._
 
-  protected sealed trait IRT {
-    def zpe: ZioType
-  }
-  protected object IRT {
-    sealed trait Monadic extends IRT
-    sealed trait Leaf extends IRT
-    case class Fail(error: IRT)(val zpe: ZioType) extends Monadic
-    case class While(cond: IRT, body: IRT)(val zpe: ZioType) extends Monadic
-    case class ValDef(originalStmt: macroQuotes.reflect.Block, symbol: Symbol, assignment: IRT, bodyUsingVal: IRT)(val zpe: ZioType) extends Monadic
-    case class Unsafe(body: IRT)(val zpe: ZioType) extends Monadic
-    case class Try(tryBlock: IRT, cases: List[IRT.Match.CaseDef], resultType: TypeRepr, finallyBlock: Option[IRT])(val zpe: ZioType) extends Monadic
-    case class Foreach(list: IRT, listType: TypeRepr, elementSymbol: Symbol, body: IRT)(val zpe: ZioType) extends Monadic
-    case class FlatMap(monad: Monadic, valSymbol: Option[Symbol], body: IRT.Monadic)(val zpe: ZioType) extends Monadic
-    case class Map(monad: Monadic, valSymbol: Option[Symbol], body: IRT.Pure)(val zpe: ZioType) extends Monadic
-    case class Monad(code: Term, source: IR.Monad.Source)(val zpe: ZioType) extends Monadic with Leaf
-    object Monad {
-      def fromZioValue(zv: ZioValue) =
-        apply(zv.term, IR.Monad.Source.Pipeline)(zv.zpe)
-    }
+  object ComputeIRT {
+    private def applyCaseDef(ir: IR.Match.CaseDef)(implicit typeUnion: TypeUnion): IRT.Match.CaseDef =
+      val rhsIRT = apply(ir.rhs)
+      IRT.Match.CaseDef(ir.pattern, ir.guard, rhsIRT)(rhsIRT.zpe)
 
-    case class Block(head: Statement, tail: Monadic)(val zpe: ZioType) extends Monadic
-    case class Match(scrutinee: IRT, caseDefs: List[IRT.Match.CaseDef])(val zpe: ZioType) extends Monadic
-    case class If(cond: IRT, ifTrue: IRT, ifFalse: IRT)(val zpe: ZioType) extends Monadic
-    case class Pure(code: Term)(val zpe: ZioType) extends IRT with Leaf
-    object Pure {
-      def fromTerm(term: Term) = Pure(term)(ZioType.fromPure(term))
-    }
-    case class And(left: IRT, right: IRT)(val zpe: ZioType) extends Monadic
-    case class Or(left: IRT, right: IRT)(val zpe: ZioType) extends Monadic
-    case class Parallel(originalExpr: Term, monads: List[(IRT.Monadic, Symbol)], body: IRT.Leaf)(val zpe: ZioType) extends Monadic
-    object Match {
-      case class CaseDef(pattern: Tree, guard: Option[Term], rhs: Monadic)(val zpe: ZioType)
-    }
+    // TODO should introduce IR/IRT.CaseDefs as a separate module that can hold a type
+    //      so that this doesn't need to be recomputed
+    def applyCaseDefs(caseDefs: List[IRT.Match.CaseDef])(implicit typeUnion: TypeUnion) =
+      ZioType.composeN(caseDefs.map(_.zpe)).transformA(_.widen)
 
-    object Compute {
-      private def applyCaseDef(ir: IR.Match.CaseDef)(implicit typeUnion: TypeUnion): IRT.Match.CaseDef =
-        val rhsIRT = apply(ir.rhs)
-        IRT.Match.CaseDef(ir.pattern, ir.guard, rhsIRT)(rhsIRT.zpe)
+    def apply(ir: IR.Monadic)(implicit typeUnion: TypeUnion): IRT.Monadic =
+      ir match
+        case ir: IR.Fail     => apply(ir)
+        case ir: IR.While    => apply(ir)
+        case ir: IR.ValDef   => apply(ir)
+        case ir: IR.Unsafe   => apply(ir)
+        case ir: IR.Try      => apply(ir)
+        case ir: IR.Foreach  => apply(ir)
+        case ir: IR.FlatMap  => apply(ir)
+        case ir: IR.Map      => apply(ir)
+        case ir: IR.Monad    => apply(ir)
+        case ir: IR.Block    => apply(ir)
+        case ir: IR.Match    => apply(ir)
+        case ir: IR.If       => apply(ir)
+        case ir: IR.And      => apply(ir)
+        case ir: IR.Or       => apply(ir)
+        case ir: IR.Parallel => apply(ir)
 
-      // TODO should introduce IR/IRT.CaseDefs as a separate module that can hold a type
-      //      so that this doesn't need to be recomputed
-      def applyCaseDefs(caseDefs: List[IRT.Match.CaseDef])(implicit typeUnion: TypeUnion) =
-        ZioType.composeN(caseDefs.map(_.zpe)).transformA(_.widen)
+    def apply(ir: IR.Leaf)(implicit typeUnion: TypeUnion): IRT.Leaf =
+      ir match
+        case ir: IR.Monad => apply(ir)
+        case ir: IR.Pure  => apply(ir)
 
-      def apply(ir: IR.Monadic)(implicit typeUnion: TypeUnion): IRT.Monadic =
-        ir match
-          case ir: IR.Fail     => apply(ir)
-          case ir: IR.While    => apply(ir)
-          case ir: IR.ValDef   => apply(ir)
-          case ir: IR.Unsafe   => apply(ir)
-          case ir: IR.Try      => apply(ir)
-          case ir: IR.Foreach  => apply(ir)
-          case ir: IR.FlatMap  => apply(ir)
-          case ir: IR.Map      => apply(ir)
-          case ir: IR.Monad    => apply(ir)
-          case ir: IR.Block    => apply(ir)
-          case ir: IR.Match    => apply(ir)
-          case ir: IR.If       => apply(ir)
-          case ir: IR.And      => apply(ir)
-          case ir: IR.Or       => apply(ir)
-          case ir: IR.Parallel => apply(ir)
+    def apply(ir: IR)(implicit typeUnion: TypeUnion): IRT =
+      ir match
+        case ir: IR.Monadic => apply(ir)
+        case ir: IR.Leaf    => apply(ir)
 
-      def apply(ir: IR.Leaf)(implicit typeUnion: TypeUnion): IRT.Leaf =
-        ir match
-          case ir: IR.Monad => apply(ir)
-          case ir: IR.Pure  => apply(ir)
+    def apply(ir: IR.Monad)(implicit typeUnion: TypeUnion): IRT.Monad =
+      IRT.Monad(ir.code, ir.source)(ZioType.fromZIO(ir.code))
 
-      def apply(ir: IR)(implicit typeUnion: TypeUnion): IRT =
-        ir match
-          case ir: IR.Monadic => apply(ir)
-          case ir: IR.Leaf    => apply(ir)
+    def apply(ir: IR.Pure)(implicit typeUnion: TypeUnion): IRT.Pure =
+      IRT.Pure(ir.code)(ZioType.fromPure(ir.code))
 
-      def apply(ir: IR.Monad)(implicit typeUnion: TypeUnion): IRT.Monad =
-        IRT.Monad(ir.code, ir.source)(ZioType.fromZIO(ir.code))
+    def apply(ir: IR.Fail)(implicit typeUnion: TypeUnion): IRT.Fail =
+      ir match
+        case IR.Fail(error) =>
+          // The error type often is a single expression e.g. someFunctionThatThrowsError()
+          // so we need to widen it into the underlying type
+          val bodyError = apply(error)
+          val tpe = ZioType(bodyError.zpe.r, bodyError.zpe.a.widenTermRefByName, TypeRepr.of[Nothing])
+          IRT.Fail(bodyError)(tpe)
 
-      def apply(ir: IR.Pure)(implicit typeUnion: TypeUnion): IRT.Pure =
-        IRT.Pure(ir.code)(ZioType.fromPure(ir.code))
+    def apply(ir: IR.While)(implicit typeUnion: TypeUnion): IRT.While =
+      ir match
+        case IR.While(cond, body) =>
+          val condIRT = apply(cond)
+          val bodyIRT = apply(body)
+          val zpe = condIRT.zpe.flatMappedWith(bodyIRT.zpe).mappedWithType(TypeRepr.of[Unit])
+          IRT.While(condIRT, bodyIRT)(zpe)
 
-      def apply(ir: IR.Fail)(implicit typeUnion: TypeUnion): IRT.Fail =
-        ir match
-          case IR.Fail(error) =>
-            // The error type often is a single expression e.g. someFunctionThatThrowsError()
-            // so we need to widen it into the underlying type
-            val bodyError = apply(error)
-            val tpe = ZioType(bodyError.zpe.r, bodyError.zpe.a.widenTermRefByName, TypeRepr.of[Nothing])
-            IRT.Fail(bodyError)(tpe)
+    def apply(ir: IR.ValDef)(implicit typeUnion: TypeUnion): IRT.ValDef =
+      ir match
+        case IR.ValDef(originalStmt, symbol, assignment, bodyUsingVal) =>
+          // Eventually a ValDef will be turned into a flatMap so if we still have one,
+          // the type-computation essentially is the same as the one for the flatMap
+          //   val symbol = assignment
+          //   bodyUsingVal
+          // Basically becomes:
+          //   assignment.flatMap { symbol =>
+          //     bodyUsingVal
+          //   }
+          // Theis essentially means that `assignment` is the monad-equivalent
+          // of flatMap and the bodyUsingVal is the body-equivalent.
+          val assignmentIRT = apply(assignment)
+          val bodyIRT = apply(bodyUsingVal)
+          val zpe = assignmentIRT.zpe.flatMappedWith(bodyIRT.zpe)
+          IRT.ValDef(ir.originalStmt, ir.symbol, assignmentIRT, bodyIRT)(zpe)
 
-      def apply(ir: IR.While)(implicit typeUnion: TypeUnion): IRT.While =
-        ir match
-          case IR.While(cond, body) =>
-            val condIRT = apply(cond)
-            val bodyIRT = apply(body)
-            val zpe = condIRT.zpe.flatMappedWith(bodyIRT.zpe).mappedWithType(TypeRepr.of[Unit])
-            IRT.While(condIRT, bodyIRT)(zpe)
+    def apply(ir: IR.Unsafe)(implicit typeUnion: TypeUnion): IRT.Unsafe =
+      ir match
+        case IR.Unsafe(body) =>
+          // Things inside Unsafe blocks that are not inside runs will be wrapepd into ZIO.attempt
+          // which will make their lower-bound Throwable in the MonadifyTries phase.
+          // Do not need to do that manually here with the `e` type though.
+          val unsafeIRT = apply(body)
+          val zpe = unsafeIRT.zpe
+          IRT.Unsafe(unsafeIRT)(zpe)
 
-      def apply(ir: IR.ValDef)(implicit typeUnion: TypeUnion): IRT.ValDef =
-        ir match
-          case IR.ValDef(originalStmt, symbol, assignment, bodyUsingVal) =>
-            // Eventually a ValDef will be turned into a flatMap so if we still have one,
-            // the type-computation essentially is the same as the one for the flatMap
-            //   val symbol = assignment
-            //   bodyUsingVal
-            // Basically becomes:
-            //   assignment.flatMap { symbol =>
-            //     bodyUsingVal
-            //   }
-            // Theis essentially means that `assignment` is the monad-equivalent
-            // of flatMap and the bodyUsingVal is the body-equivalent.
-            val assignmentIRT = apply(assignment)
-            val bodyIRT = apply(bodyUsingVal)
-            val zpe = assignmentIRT.zpe.flatMappedWith(bodyIRT.zpe)
-            IRT.ValDef(ir.originalStmt, ir.symbol, assignmentIRT, bodyIRT)(zpe)
+    def apply(ir: IR.Try)(implicit typeUnion: TypeUnion): IRT.Try =
+      ir match
+        case IR.Try(tryBlock, caseDefs, resultType, finallyBlock) =>
+          val tryBlockIRT = apply(tryBlock)
+          val caseDefIRTs = caseDefs.map(applyCaseDef(_))
 
-      def apply(ir: IR.Unsafe)(implicit typeUnion: TypeUnion): IRT.Unsafe =
-        ir match
-          case IR.Unsafe(body) =>
-            // Things inside Unsafe blocks that are not inside runs will be wrapepd into ZIO.attempt
-            // which will make their lower-bound Throwable in the MonadifyTries phase.
-            // Do not need to do that manually here with the `e` type though.
-            val unsafeIRT = apply(body)
-            val zpe = unsafeIRT.zpe
-            IRT.Unsafe(unsafeIRT)(zpe)
+          // We get better results by doing into the case-defs and computing the union-type of them
+          // than we do by getting the information from outputType because outputType is limited
+          // by Scala's ability to understand the try-catch. For example, if we infer from outputType,
+          // the error-type will never be more concrete that `Throwable`.
+          // (Note, widen the error type because even if it's a concrete int type
+          // e.g. `catch { case e: Throwable => 111 }` we don't necessarily know
+          // that this error will actually happen therefore it's not sensical to make it a singleton type)
+          val caseDefType = applyCaseDefs(caseDefIRTs)
 
-      def apply(ir: IR.Try)(implicit typeUnion: TypeUnion): IRT.Try =
-        ir match
-          case IR.Try(tryBlock, caseDefs, resultType, finallyBlock) =>
-            val tryBlockIRT = apply(tryBlock)
-            val caseDefIRTs = caseDefs.map(applyCaseDef(_))
+          // Could also apply from outputType but this has worse results, see comment above.
+          // val caseDefType =
+          //   outputType.asType match
+          //     case '[ZIO[r, e, a]] => ZioType(TypeRepr.of[r].widen, TypeRepr.of[e].widen, TypeRepr.of[a].widen)
+          //     case '[t]            => ZioType(TypeRepr.of[Any].widen, TypeRepr.of[Throwable].widen, TypeRepr.of[t].widen)
+          val tpe = tryBlockIRT.zpe.flatMappedWith(caseDefType)
+          val finallyBlockIRT = finallyBlock.map(apply(_))
+          IRT.Try(tryBlockIRT, caseDefIRTs, ir.resultType, finallyBlockIRT)(tpe)
 
-            // We get better results by doing into the case-defs and computing the union-type of them
-            // than we do by getting the information from outputType because outputType is limited
-            // by Scala's ability to understand the try-catch. For example, if we infer from outputType,
-            // the error-type will never be more concrete that `Throwable`.
-            // (Note, widen the error type because even if it's a concrete int type
-            // e.g. `catch { case e: Throwable => 111 }` we don't necessarily know
-            // that this error will actually happen therefore it's not sensical to make it a singleton type)
-            val caseDefType = applyCaseDefs(caseDefIRTs)
+    def apply(ir: IR.Foreach)(implicit typeUnion: TypeUnion): IRT.Foreach =
+      ir match
+        case IR.Foreach(monad, _, _, body) =>
+          val monadIRT = apply(monad)
+          val bodyIRT = apply(body)
+          val zpe =
+            ZioType.fromMulti(
+              List(bodyIRT.zpe.r, monadIRT.zpe.r),
+              List(bodyIRT.zpe.e, monadIRT.zpe.e),
+              List(TypeRepr.of[Unit])
+            )
+          IRT.Foreach(monadIRT, ir.listType, ir.elementSymbol, bodyIRT)(zpe)
 
-            // Could also apply from outputType but this has worse results, see comment above.
-            // val caseDefType =
-            //   outputType.asType match
-            //     case '[ZIO[r, e, a]] => ZioType(TypeRepr.of[r].widen, TypeRepr.of[e].widen, TypeRepr.of[a].widen)
-            //     case '[t]            => ZioType(TypeRepr.of[Any].widen, TypeRepr.of[Throwable].widen, TypeRepr.of[t].widen)
-            val tpe = tryBlockIRT.zpe.flatMappedWith(caseDefType)
-            val finallyBlockIRT = finallyBlock.map(apply(_))
-            IRT.Try(tryBlockIRT, caseDefIRTs, ir.resultType, finallyBlockIRT)(tpe)
+    def apply(ir: IR.FlatMap)(implicit typeUnion: TypeUnion): IRT.FlatMap =
+      ir match
+        case IR.FlatMap(monad, valSymbol, body) =>
+          val monadIRT = apply(monad)
+          val bodyIRT = apply(body)
+          val zpe = monadIRT.zpe.flatMappedWith(bodyIRT.zpe)
+          IRT.FlatMap(monadIRT, ir.valSymbol, bodyIRT)(zpe)
 
-      def apply(ir: IR.Foreach)(implicit typeUnion: TypeUnion): IRT.Foreach =
-        ir match
-          case IR.Foreach(monad, _, _, body) =>
-            val monadIRT = apply(monad)
-            val bodyIRT = apply(body)
-            val zpe =
-              ZioType.fromMulti(
-                List(bodyIRT.zpe.r, monadIRT.zpe.r),
-                List(bodyIRT.zpe.e, monadIRT.zpe.e),
-                List(TypeRepr.of[Unit])
-              )
-            IRT.Foreach(monadIRT, ir.listType, ir.elementSymbol, bodyIRT)(zpe)
+    def apply(ir: IR.Map)(implicit typeUnion: TypeUnion): IRT.Map =
+      ir match
+        case IR.Map(monad, valSymbol, body @ IR.Pure(term)) =>
+          val monadIRT = apply(monad)
+          val zpe = monadIRT.zpe.mappedWith(term)
+          IRT.Map(monadIRT, ir.valSymbol, IRT.Pure.fromTerm(term))(zpe)
 
-      def apply(ir: IR.FlatMap)(implicit typeUnion: TypeUnion): IRT.FlatMap =
-        ir match
-          case IR.FlatMap(monad, valSymbol, body) =>
-            val monadIRT = apply(monad)
-            val bodyIRT = apply(body)
-            val zpe = monadIRT.zpe.flatMappedWith(bodyIRT.zpe)
-            IRT.FlatMap(monadIRT, ir.valSymbol, bodyIRT)(zpe)
+    def apply(ir: IR.Block)(implicit typeUnion: TypeUnion): IRT.Block =
+      ir match
+        case IR.Block(head, tail) =>
+          val tailIRT = apply(tail)
+          IRT.Block(head, tailIRT)(tailIRT.zpe)
 
-      def apply(ir: IR.Map)(implicit typeUnion: TypeUnion): IRT.Map =
-        ir match
-          case IR.Map(monad, valSymbol, body @ IR.Pure(term)) =>
-            val monadIRT = apply(monad)
-            val zpe = monadIRT.zpe.mappedWith(term)
-            IRT.Map(monadIRT, ir.valSymbol, IRT.Pure.fromTerm(term))(zpe)
+    def apply(ir: IR.Match)(implicit typeUnion: TypeUnion): IRT.Match =
+      ir match
+        case IR.Match(scrutinee, caseDefs) =>
+          // Ultimately the scrutinee will be used if it is pure or lifted, either way we can
+          // treat it as a value that will be flatMapped (or Mapped) against the caseDef values.
+          val scrutineeIRT = apply(scrutinee)
+          // NOTE: We can possibly do the same thing as IR.Try and pass through the Match result tpe, then
+          // then use that to figure out what the type should be
+          val caseDefIRTs = caseDefs.map(applyCaseDef(_))
+          val caseDefType = ZioType.composeN(caseDefIRTs.map(_.zpe)).transformA(_.widen)
+          val zpe = scrutineeIRT.zpe.flatMappedWith(caseDefType)
+          IRT.Match(scrutineeIRT, caseDefIRTs)(zpe)
 
-      def apply(ir: IR.Block)(implicit typeUnion: TypeUnion): IRT.Block =
-        ir match
-          case IR.Block(head, tail) =>
-            val tailIRT = apply(tail)
-            IRT.Block(head, tailIRT)(tailIRT.zpe)
+    def apply(ir: IR.Parallel)(implicit typeUnion: TypeUnion): IRT.Parallel =
+      ir match
+        case IR.Parallel(_, monadics, body) =>
+          val monadicsIRTs =
+            monadics.map((monadic, sym) => (apply(monadic), sym))
 
-      def apply(ir: IR.Match)(implicit typeUnion: TypeUnion): IRT.Match =
-        ir match
-          case IR.Match(scrutinee, caseDefs) =>
-            // Ultimately the scrutinee will be used if it is pure or lifted, either way we can
-            // treat it as a value that will be flatMapped (or Mapped) against the caseDef values.
-            val scrutineeIRT = apply(scrutinee)
-            // NOTE: We can possibly do the same thing as IR.Try and pass through the Match result tpe, then
-            // then use that to figure out what the type should be
-            val caseDefIRTs = caseDefs.map(applyCaseDef(_))
-            val caseDefType = ZioType.composeN(caseDefIRTs.map(_.zpe)).transformA(_.widen)
-            val zpe = scrutineeIRT.zpe.flatMappedWith(caseDefType)
-            IRT.Match(scrutineeIRT, caseDefIRTs)(zpe)
+          // a IR.Leaf will either be a IR.Pure or an IR.Monad, both already have cases here
+          val bodyIRT = apply(body).asInstanceOf[IRT.Leaf]
 
-      def apply(ir: IR.Parallel)(implicit typeUnion: TypeUnion): IRT.Parallel =
-        ir match
-          case IR.Parallel(_, monadics, body) =>
-            val monadicsIRTs =
-              monadics.map((monadic, sym) => (apply(monadic), sym))
+          // For some arbitrary structure that contains monads e.g:
+          //   ((foo:ZIO[ConfA,ExA,A]).run, (bar:ZIO[ConfB,ExB,B]).run)
+          // This will turn into something like:
+          //   ZIO.collectAll(foo, bar).map(col => {val iter = col.iter; (iter.next, iter.next)}) which has the type
+          // That means that the output signature will be a ZIO of the following:
+          //   R-Parameter: ConfA & ConfB, E-Parameter: ExA | ExB, A-Parameter: (A, B)
+          // In some cases the above function will be a flatMap and wrapped into a ZIO.attempt or ZIO.succeed
+          //   so we include the body-type error and environment just in case
+          val zpe =
+            ZioType.fromMulti(
+              bodyIRT.zpe.r +: monadicsIRTs.map { (mon, _) => mon.zpe.r },
+              bodyIRT.zpe.e +: monadicsIRTs.map { (mon, _) => mon.zpe.e },
+              List(bodyIRT.zpe.a)
+            )
 
-            // a IR.Leaf will either be a IR.Pure or an IR.Monad, both already have cases here
-            val bodyIRT = apply(body).asInstanceOf[IRT.Leaf]
+          IRT.Parallel(ir.originalExpr, monadicsIRTs, bodyIRT)(zpe)
 
-            // For some arbitrary structure that contains monads e.g:
-            //   ((foo:ZIO[ConfA,ExA,A]).run, (bar:ZIO[ConfB,ExB,B]).run)
-            // This will turn into something like:
-            //   ZIO.collectAll(foo, bar).map(col => {val iter = col.iter; (iter.next, iter.next)}) which has the type
-            // That means that the output signature will be a ZIO of the following:
-            //   R-Parameter: ConfA & ConfB, E-Parameter: ExA | ExB, A-Parameter: (A, B)
-            // In some cases the above function will be a flatMap and wrapped into a ZIO.attempt or ZIO.succeed
-            //   so we include the body-type error and environment just in case
-            val zpe =
-              ZioType.fromMulti(
-                bodyIRT.zpe.r +: monadicsIRTs.map { (mon, _) => mon.zpe.r },
-                bodyIRT.zpe.e +: monadicsIRTs.map { (mon, _) => mon.zpe.e },
-                List(bodyIRT.zpe.a)
-              )
+    def apply(ir: IR.If)(implicit typeUnion: TypeUnion): IRT.If =
+      ir match
+        case IR.If(cond, ifTrue, ifFalse) =>
+          val condIRT = apply(cond)
+          val ifTrueIRT = apply(ifTrue)
+          val ifFalseIRT = apply(ifFalse)
+          // Something like this: if (a) then b else c
+          // Becomes something like this: a.flatMap(av => if (av) b.flatMap(...) else c.flatMap(...))
+          // So the output type is the a.flatMappedWith(b compose c)
+          val zpe =
+            condIRT.zpe.flatMappedWith(
+              ZioType.compose(ifTrueIRT.zpe, ifFalseIRT.zpe)
+            )
+          IRT.If(condIRT, ifTrueIRT, ifFalseIRT)(zpe)
 
-            IRT.Parallel(ir.originalExpr, monadicsIRTs, bodyIRT)(zpe)
+    def apply(ir: IR.And)(implicit typeUnion: TypeUnion): IRT.And =
+      ir match
+        case IR.And(left, right) =>
+          val leftIRT = apply(left)
+          val rightIRT = apply(right)
+          val zpe = ZioType.compose(leftIRT.zpe, rightIRT.zpe)
+          IRT.And(leftIRT, rightIRT)(zpe)
 
-      def apply(ir: IR.If)(implicit typeUnion: TypeUnion): IRT.If =
-        ir match
-          case IR.If(cond, ifTrue, ifFalse) =>
-            val condIRT = apply(cond)
-            val ifTrueIRT = apply(ifTrue)
-            val ifFalseIRT = apply(ifFalse)
-            // Something like this: if (a) then b else c
-            // Becomes something like this: a.flatMap(av => if (av) b.flatMap(...) else c.flatMap(...))
-            // So the output type is the a.flatMappedWith(b compose c)
-            val zpe =
-              condIRT.zpe.flatMappedWith(
-                ZioType.compose(ifTrueIRT.zpe, ifFalseIRT.zpe)
-              )
-            IRT.If(condIRT, ifTrueIRT, ifFalseIRT)(zpe)
-
-      def apply(ir: IR.And)(implicit typeUnion: TypeUnion): IRT.And =
-        ir match
-          case IR.And(left, right) =>
-            val leftIRT = apply(left)
-            val rightIRT = apply(right)
-            val zpe = ZioType.compose(leftIRT.zpe, rightIRT.zpe)
-            IRT.And(leftIRT, rightIRT)(zpe)
-
-      def apply(ir: IR.Or)(implicit typeUnion: TypeUnion): IRT.Or =
-        ir match
-          case IR.Or(left, right) =>
-            val leftIRT = apply(left)
-            val rightIRT = apply(right)
-            val zpe = ZioType.compose(leftIRT.zpe, rightIRT.zpe)
-            IRT.Or(leftIRT, rightIRT)(zpe)
-    }
+    def apply(ir: IR.Or)(implicit typeUnion: TypeUnion): IRT.Or =
+      ir match
+        case IR.Or(left, right) =>
+          val leftIRT = apply(left)
+          val rightIRT = apply(right)
+          val zpe = ZioType.compose(leftIRT.zpe, rightIRT.zpe)
+          IRT.Or(leftIRT, rightIRT)(zpe)
   }
 }

--- a/zio-direct/src/main/scala-3.x/zio/direct/core/norm/WithDecomposeTree.scala
+++ b/zio-direct/src/main/scala-3.x/zio/direct/core/norm/WithDecomposeTree.scala
@@ -21,7 +21,7 @@ import zio.direct.core.util.Unsupported
 import zio.direct.core.util.WithInterpolator
 
 trait WithDecomposeTree {
-  self: WithIR with WithZioType with WithComputeType with WithInterpolator with WithPrintIR =>
+  self: WithIR with WithZioType =>
 
   implicit val macroQuotes: Quotes
   import macroQuotes.reflect._

--- a/zio-direct/src/main/scala-3.x/zio/direct/core/norm/WithDecomposeTree.scala
+++ b/zio-direct/src/main/scala-3.x/zio/direct/core/norm/WithDecomposeTree.scala
@@ -147,6 +147,7 @@ trait WithDecomposeTree {
 
                 case originalTerm @ DecomposeSingleTermConstruct(monad) =>
                   val tpe = originalTerm.tpe
+                  println(s"************* Original Term: ${originalTerm.show}. Type: ${originalTerm.tpe.show}")
                   val sym = Symbol.newVal(Symbol.spliceOwner, "singleVal", tpe, Flags.EmptyFlags, Symbol.noSymbol)
                   unlifts += ((monad, sym))
                   Ref(sym)

--- a/zio-direct/src/main/scala-3.x/zio/direct/core/norm/WithDecomposeTree.scala
+++ b/zio-direct/src/main/scala-3.x/zio/direct/core/norm/WithDecomposeTree.scala
@@ -266,7 +266,7 @@ trait WithDecomposeTree {
               case '[ZIO[r, e, a]] =>
                 Some(IR.Monad(code.asTerm, IR.Monad.Source.IgnoreCall))
               case _ =>
-                Some(IR.Monad(ZioApply.succeed(code.asTerm).asTerm))
+                Some(IR.Monad(ZioApply.succeed(code.asTerm)))
             }
 
           case tryTerm @ Try(tryBlock, caseDefs, finallyBlock) =>
@@ -291,7 +291,7 @@ trait WithDecomposeTree {
           case CaseDef(pattern, cond, DecomposeTree(body)) =>
             IR.Match.CaseDef(pattern, cond, body)
           case CaseDef(pattern, cond, body) =>
-            IR.Match.CaseDef(pattern, cond, IR.Monad(ZioApply.succeed(body).asTerm))
+            IR.Match.CaseDef(pattern, cond, IR.Monad(ZioApply.succeed(body)))
         }
 
       def unapply(cases: List[CaseDef]) =

--- a/zio-direct/src/main/scala-3.x/zio/direct/core/norm/WithDecomposeTree.scala
+++ b/zio-direct/src/main/scala-3.x/zio/direct/core/norm/WithDecomposeTree.scala
@@ -20,7 +20,7 @@ import zio.direct.Internal.ignore
 import zio.direct.core.util.Unsupported
 
 trait WithDecomposeTree {
-  self: WithIR =>
+  self: WithIR with WithZioType =>
 
   implicit val macroQuotes: Quotes
   import macroQuotes.reflect._

--- a/zio-direct/src/main/scala-3.x/zio/direct/core/norm/WithDecomposeTree.scala
+++ b/zio-direct/src/main/scala-3.x/zio/direct/core/norm/WithDecomposeTree.scala
@@ -18,9 +18,10 @@ import zio.direct.core.util.ShowDetails
 import zio.direct.Internal.deferred
 import zio.direct.Internal.ignore
 import zio.direct.core.util.Unsupported
+import zio.direct.core.util.WithInterpolator
 
 trait WithDecomposeTree {
-  self: WithIR with WithZioType =>
+  self: WithIR with WithZioType with WithComputeType with WithInterpolator with WithPrintIR =>
 
   implicit val macroQuotes: Quotes
   import macroQuotes.reflect._
@@ -267,7 +268,7 @@ trait WithDecomposeTree {
               case '[ZIO[r, e, a]] =>
                 Some(IR.Monad(code.asTerm, IR.Monad.Source.IgnoreCall))
               case _ =>
-                Some(IR.Monad(ZioApply.succeed(code.asTerm)))
+                Some(IR.Monad(ZioValue(ZioType.Unit).succeed(code.asTerm).term))
             }
 
           case tryTerm @ Try(tryBlock, caseDefs, finallyBlock) =>
@@ -292,7 +293,7 @@ trait WithDecomposeTree {
           case CaseDef(pattern, cond, DecomposeTree(body)) =>
             IR.Match.CaseDef(pattern, cond, body)
           case CaseDef(pattern, cond, body) =>
-            IR.Match.CaseDef(pattern, cond, IR.Monad(ZioApply.succeed(body)))
+            IR.Match.CaseDef(pattern, cond, IR.Monad(ZioValue(ZioType.Unit).succeed(body).term))
         }
 
       def unapply(cases: List[CaseDef]) =

--- a/zio-direct/src/main/scala-3.x/zio/direct/core/norm/WithReconstructTree.scala
+++ b/zio-direct/src/main/scala-3.x/zio/direct/core/norm/WithReconstructTree.scala
@@ -80,7 +80,8 @@ trait WithReconstructTree {
               Apply(
                 Apply(
                   TypeApply(
-                    Select.unique(monadExpr.asTerm, "flatMap"),
+                    // still need to do .asInstanceOf[ZIO[?, ?, t]] otherwise various tests will fail because .asExprOf is used everywhere
+                    Select.unique('{ $monadExpr.asInstanceOf[ZIO[?, ?, t]] }.asTerm, "flatMap"),
                     List(Inferred(anyToNothing), Inferred(anyToNothing), Inferred(anyToNothing))
                     // List(Inferred(TypeRepr.of[AnyKind]), Inferred(TypeRepr.of[AnyKind]), Inferred(TypeRepr.of[AnyKind]))
                     // List(TypeTree.ref(Wildcard().symbol), TypeTree.ref(Wildcard().symbol), TypeTree.ref(Wildcard().symbol))

--- a/zio-direct/src/main/scala-3.x/zio/direct/core/norm/WithReconstructTree.scala
+++ b/zio-direct/src/main/scala-3.x/zio/direct/core/norm/WithReconstructTree.scala
@@ -126,6 +126,7 @@ trait WithReconstructTree {
                         ${ replaceSymbolInBodyMaybe(using macroQuotes)(body.changeOwner('v.asTerm.symbol))(valSymbol, ('v).asTerm).asExpr }
                   )
                     // make the lambda accept anything because the symbol-type computations for what `t` is are not always correct for what `t` is are not always
+                    // maybe something like this is needed for the flatMap case too?
                     .asInstanceOf[Any => ?]
                 }.asTerm
               applyMap(monadExpr, applyLambda)
@@ -143,7 +144,7 @@ trait WithReconstructTree {
             case '[t] =>
               val applyLambda =
                 '{ (v: t) =>
-                  ${ replaceSymbolInBodyMaybe(using macroQuotes)(bodyExpr)(valSymbol, ('v).asTerm).asExprOf[ZIO[?, ?, ?]] }
+                  ${ replaceSymbolInBodyMaybe(using macroQuotes)(bodyExpr.changeOwner('v.asTerm.symbol))(valSymbol, ('v).asTerm).asExprOf[ZIO[?, ?, ?]] }
                 }.asTerm
               applyFlatMap(monadExpr, applyLambda)
         }

--- a/zio-direct/src/main/scala-3.x/zio/direct/core/norm/WithReconstructTree.scala
+++ b/zio-direct/src/main/scala-3.x/zio/direct/core/norm/WithReconstructTree.scala
@@ -257,7 +257,7 @@ trait WithReconstructTree {
         case irt @ IRT.Try(tryBlock, cases, _, finallyBlock) =>
           val tryBlockType = tryBlock.zpe
           val newCaseDefs = reconstructCaseDefs(cases)
-          val caseDefsType = IRT.Compute.applyCaseDefs(cases)
+          val caseDefsType = ComputeIRT.applyCaseDefs(cases)
           val tryTerm = apply(tryBlock)
 
           (tryBlockType.toZioType.asType, tryBlockType.e.asType, irt.zpe.toZioType.asType) match
@@ -330,7 +330,7 @@ trait WithReconstructTree {
 
           // TODO should introduce IR/IRT.CaseDefs as a separate module that can hold a type
           //      so that this doesn't need to be recomputed
-          val caseDefType = IRT.Compute.applyCaseDefs(caseDefs)
+          val caseDefType = ComputeIRT.applyCaseDefs(caseDefs)
 
           // Possible exploration: if the content of the match is pure we lifted it into a monad. If we want to optimize we
           // change the IRT.CaseDef.rhs to be IRT.Pure as well as IRT.Monadic and handle both cases

--- a/zio-direct/src/main/scala-3.x/zio/direct/core/norm/WithReconstructTree.scala
+++ b/zio-direct/src/main/scala-3.x/zio/direct/core/norm/WithReconstructTree.scala
@@ -186,8 +186,10 @@ trait WithReconstructTree {
             case '[t] =>
               val applyLambda =
                 '{
-                  (v: t) =>
-                    ${ replaceSymbolInBodyMaybe(using macroQuotes)(body)(valSymbol, ('v).asTerm).asExpr }
+                  (
+                      (v: t) =>
+                        ${ replaceSymbolInBodyMaybe(using macroQuotes)(body)(valSymbol, ('v).asTerm).asExpr }
+                  ).asInstanceOf[Any => ?]
                 }.asTerm
               applyMap(monadExpr, applyLambda)
 

--- a/zio-direct/src/main/scala-3.x/zio/direct/core/norm/WithResolver.scala
+++ b/zio-direct/src/main/scala-3.x/zio/direct/core/norm/WithResolver.scala
@@ -21,7 +21,7 @@ import zio.direct.core.metaprog.Collect.Parallel
 import java.lang.reflect.WildcardType
 
 trait WithResolver {
-  self: WithIR with WithZioType with WithComputeType with WithPrintIR with WithInterpolator =>
+  self: WithIR with WithZioType =>
 
   implicit val macroQuotes: Quotes
   import macroQuotes.reflect._

--- a/zio-direct/src/main/scala-3.x/zio/direct/core/norm/WithResolver.scala
+++ b/zio-direct/src/main/scala-3.x/zio/direct/core/norm/WithResolver.scala
@@ -1,0 +1,160 @@
+package zio.direct.core.norm
+
+import zio.direct.core.metaprog.WithIR
+import scala.quoted._
+import zio.direct.core.metaprog.Embedder._
+import zio.ZIO
+import zio.direct.core.metaprog.WithPrintIR
+import zio.Chunk
+import zio.direct.core.util.Format
+import zio.direct.core.util.WithInterpolator
+import zio.Exit.Success
+import zio.Exit.Failure
+import zio.direct.core.metaprog.Instructions
+import zio.direct.core.metaprog.Collect
+import zio.direct.core.metaprog.WithZioType
+import zio.direct.core.util.ZioUtil
+import zio.direct.core.util.Unsupported
+import org.scalafmt.util.LogLevel.info
+import zio.direct.core.metaprog.Collect.Sequence
+import zio.direct.core.metaprog.Collect.Parallel
+import java.lang.reflect.WildcardType
+
+trait WithResolver {
+  self: WithIR with WithZioType with WithComputeType with WithPrintIR with WithInterpolator =>
+
+  implicit val macroQuotes: Quotes
+  import macroQuotes.reflect._
+
+  private object CommonTypes {
+    val anyToNothing = TypeBounds(TypeRepr.of[Nothing], TypeRepr.of[Any])
+    val inf = Inferred(anyToNothing)
+  }
+
+  object Resolver {
+    def applyFlatMap(monadExpr: Term, applyLambda: Term) = {
+      val flatMapSig = Select.unique(monadExpr, "flatMap")
+      // val firstParam = flatMapMethod.symbol.paramSymss(0)(0)
+      // val firstParamType = TypeTree.ref(firstParam).tpe
+      val flatMapMethod =
+        TypeApply(
+          // still need to do .asInstanceOf[ZIO[?, ?, t]] otherwise various tests will fail because .asExprOf is used everywhere
+          flatMapSig,
+          List(CommonTypes.inf, CommonTypes.inf, CommonTypes.inf)
+          // List(Inferred(TypeRepr.of[AnyKind]), Inferred(TypeRepr.of[AnyKind]), Inferred(TypeRepr.of[AnyKind]))
+          // List(TypeTree.ref(Wildcard().symbol), TypeTree.ref(Wildcard().symbol), TypeTree.ref(Wildcard().symbol))
+        )
+
+      val flatMapMethodApply = flatMapMethod.etaExpand(Symbol.spliceOwner)
+      val valDef =
+        flatMapMethodApply match
+          case Lambda(List(valDef), term) => valDef
+          case _                          => report.errorAndAbort("Eta-expanded flatMap is not of correct form")
+
+      val firstParamType = valDef.tpt.tpe
+      Apply(
+        Apply(
+          flatMapMethod,
+          List({
+            // whatever the type of the flatMap is supposed to be cast it to that
+            firstParamType.asType match
+              case '[t] =>
+                '{ ${ applyLambda.asExpr }.asInstanceOf[t] }.asTerm
+          })
+        ),
+        List(Expr.summon[zio.Trace].get.asTerm)
+      )
+    }
+
+    def applyFlatMapWithBody(monadExpr: Term, valSymbol: Option[Symbol], bodyExpr: Term) = {
+      val applyLambda =
+        '{
+          // make the lambda accept anything because the symbol-type computations for what `t` is are not always correct for what `t` is are not always
+          // maybe something like this is needed for the flatMap case too?
+          ${ makeLambda(TypeRepr.of[ZIO[?, ?, ?]])(bodyExpr, valSymbol).asExpr }.asInstanceOf[Any => ZIO[?, ?, ?]]
+        }.asTerm
+
+      applyFlatMap(monadExpr, applyLambda)
+    }
+
+    def applyMap(monadExpr: Term, applyLambda: Term) = {
+      val out =
+        Apply(
+          Apply(
+            TypeApply(
+              // still need to do .asInstanceOf[ZIO[?, ?, t]] otherwise various tests will fail because .asExprOf is used everywhere
+              Select.unique(monadExpr, "map"),
+              List(CommonTypes.inf)
+            ),
+            List(applyLambda)
+          ),
+          List(Expr.summon[zio.Trace].get.asTerm)
+        )
+      println(s"---------------- HERE: ${monadExpr.show} ------------------")
+      out
+    }
+
+    def applyMapWithBody(monadExpr: Term, valSymbol: Option[Symbol], bodyTerm: Term) = {
+      val applyLambda =
+        '{
+          // make the lambda accept anything because the symbol-type computations for what `t` is are not always correct for what `t` is are not always
+          // maybe something like this is needed for the flatMap case too?
+          ${ makeLambda(TypeRepr.of[Any])(bodyTerm, valSymbol).asExpr }.asInstanceOf[Any => ?]
+        }.asTerm
+
+      applyMap(monadExpr, applyLambda)
+    }
+
+    def applyCatchSome(monadExpr: Term, partialFunctionLambda: Term) = {
+      // val anyToNothing = TypeBounds(TypeRepr.of[Nothing], TypeRepr.of[Any])
+      // val catchSomeMethod =
+      //   TypeApply(
+      //     Select.unique(monadExpr, "catchSome"),
+      //     List(Inferred(anyToNothing), Inferred(anyToNothing), Inferred(anyToNothing))
+      //   )
+
+      // val catchSomeMethodApply = catchSomeMethod.etaExpand(Symbol.spliceOwner)
+      // val valDef =
+      //   catchSomeMethodApply match
+      //     case Lambda(List(valDef), term) => valDef
+      //     case _                          => report.errorAndAbort("Eta-expanded catchSome is not of correct form")
+
+      // val firstParamType = valDef.tpt.tpe
+      // println(s"===== First ValDef Param type: ${valDef.tpt.tpe.show}")
+      // Apply(
+      //   Apply(
+      //     catchSomeMethod,
+      //     List({
+      //       // whatever the type of the flatMap is supposed to be cast it to that
+      //       firstParamType.asType match
+      //         case '[t] =>
+      //       '{ ${ partialFunctionLambda.asExpr }.asInstanceOf[PFT] }.asTerm
+      //     })
+      //   ),
+      //   List('{ zio.CanFail }.asTerm, Expr.summon[zio.Trace].get.asTerm)
+      // )
+    }
+
+    def makeLambda(outputType: TypeRepr)(body: Term, prevValSymbolOpt: Option[Symbol]) = {
+      val prevValSymbolType =
+        prevValSymbolOpt match {
+          case Some(oldSymbol) => oldSymbol.termRef.widenTermRefByName
+          case None            => TypeRepr.of[Any]
+        }
+
+      val mtpe = MethodType(List("sm"))(_ => List(prevValSymbolType), _ => outputType)
+      println(s"lambda-type:  => ${outputType.show}") // ${inputType.show}
+
+      Lambda(
+        Symbol.spliceOwner,
+        mtpe,
+        {
+          case (methSym, List(sm: Term)) =>
+            replaceSymbolInBodyMaybe(using macroQuotes)(body)(prevValSymbolOpt, sm).changeOwner(methSym)
+          case _ =>
+            report.errorAndAbort("Not a possible state")
+        }
+      )
+    }
+  }
+}

--- a/zio-direct/src/main/scala-3.x/zio/direct/core/norm/WithResolver.scala
+++ b/zio-direct/src/main/scala-3.x/zio/direct/core/norm/WithResolver.scala
@@ -72,8 +72,8 @@ trait WithResolver {
       applyMap(monad, applyLambdaTerm)
     }
 
-    def applyCatchSome(resultType: ZioType)(tryClause: ZioValue, body: ZioValue): Term =
-      (tryClause.zpe.asTypeTuple, resultType.asTypeTuple) match
+    def applyCatchSome(tryClause: ZioValue, body: ZioValue): Term =
+      (tryClause.zpe.asTypeTuple, body.zpe.asTypeTuple) match
         case (('[rr], '[er], '[ar]), ('[r], '[e], '[b])) =>
           '{
             ${ tryClause.term.asExpr }.asInstanceOf[ZIO[rr, er, ar]]

--- a/zio-direct/src/main/scala/zio/direct/core/util/WithInterpolator.scala
+++ b/zio-direct/src/main/scala/zio/direct/core/util/WithInterpolator.scala
@@ -6,7 +6,7 @@ import zio.direct.core.metaprog.WithZioType
 import zio.direct.core.norm.WithComputeType
 
 trait WithInterpolator extends WithInterpolatorBase {
-  self: WithIR with WithZioType with WithPrintIR with WithComputeType =>
+  self: WithIR with WithZioType with WithPrintIR =>
 
   override def printAny(any: Any): String = PrintAny(any)
 }

--- a/zio-direct/src/main/scala/zio/direct/core/util/WithInterpolator.scala
+++ b/zio-direct/src/main/scala/zio/direct/core/util/WithInterpolator.scala
@@ -3,9 +3,10 @@ package zio.direct.core.util
 import zio.direct.core.metaprog.WithIR
 import zio.direct.core.metaprog.WithPrintIR
 import zio.direct.core.metaprog.WithZioType
+import zio.direct.core.norm.WithComputeType
 
 trait WithInterpolator extends WithInterpolatorBase {
-  self: WithIR with WithZioType with WithPrintIR =>
+  self: WithIR with WithZioType with WithPrintIR with WithComputeType =>
 
   override def printAny(any: Any): String = PrintAny(any)
 }


### PR DESCRIPTION
Remove explicit usages of ZIO in WithReconstructTree and delegate them to the WithResolver so it can be modified to work with the future typeclasses.