### PR TITLE
Scala 2.x support for more monads [WIP]

### DIFF
--- a/zio-direct/src/main/scala-2.x/zio/direct/core/Transformer.scala
+++ b/zio-direct/src/main/scala-2.x/zio/direct/core/Transformer.scala
@@ -113,7 +113,7 @@ abstract class Transformer
 
     val ownerPositionOpt = findEncosingOwner
     val wrappedIR = wrapUnsafes(ir, sourceFile, instructions)
-    val computedType = ComputeType.fromIR(wrappedIR)(instructions).toZioType
+    val computedType = ComputeType.fromIR(wrappedIR)(instructions).zpe.toZioType
     val output = reconstructTree(wrappedIR, sourceFile, instructions)
 
     Allowed.finalValidtyCheck(output, instructions)

--- a/zio-direct/src/main/scala-2.x/zio/direct/core/metaprog/WithIR.scala
+++ b/zio-direct/src/main/scala-2.x/zio/direct/core/metaprog/WithIR.scala
@@ -289,7 +289,9 @@ trait WithIR extends MacroBase {
   }
 
   // Typed version of IR AST
-  sealed trait IRT
+  sealed trait IRT {
+    def zpe: ZioType
+  }
   object IRT {
     sealed trait Monadic extends IRT
 
@@ -305,7 +307,7 @@ trait WithIR extends MacroBase {
 
     case class Unsafe(body: IRT)(val zpe: ZioType) extends Monadic
 
-    case class Try(tryBlock: IRT, cases: List[IR.Match.CaseDef], resultType: c.universe.Type, finallyBlock: Option[IRT])(val zpe: ZioType) extends Monadic
+    case class Try(tryBlock: IRT, cases: List[IRT.Match.CaseDef], resultType: c.universe.Type, finallyBlock: Option[IRT])(val zpe: ZioType) extends Monadic
 
     case class Foreach(list: IRT, listType: c.universe.Type, elementSymbol: TermName, body: IRT)(val zpe: ZioType) extends Monadic
 
@@ -358,7 +360,7 @@ trait WithIR extends MacroBase {
     case class Match(scrutinee: IRT, caseDefs: List[IRT.Match.CaseDef])(val zpe: ZioType) extends Monadic
 
     object Match {
-      case class CaseDef(pattern: Tree, guard: Option[c.universe.Tree], rhs: Monadic)
+      case class CaseDef(pattern: Tree, guard: Option[c.universe.Tree], rhs: Monadic)(val zpe: ZioType)
     }
 
     case class If(cond: IRT, ifTrue: IRT, ifFalse: IRT)(val zpe: ZioType) extends Monadic

--- a/zio-direct/src/main/scala-2.x/zio/direct/core/norm/WithComputeType.scala
+++ b/zio-direct/src/main/scala-2.x/zio/direct/core/norm/WithComputeType.scala
@@ -15,120 +15,195 @@ trait WithComputeType extends MacroBase {
   import c.universe._
 
   object ComputeType {
-    def fromIR(ir: IR)(implicit instructions: Instructions): ZioType =
+    def fromIR(ir: IR)(implicit instructions: Instructions): IRT =
       new ComputeType(instructions).apply(ir)
   }
 
   class ComputeType private (instructions: Instructions) {
     implicit val tu: TypeUnion = instructions.typeUnion
 
-    def apply(ir: IR): ZioType =
+    def apply(ir: IR): IRT =
       ir match {
-        case ir @ IR.Pure(code) =>
-          ZioType.fromPure(code)
-
-        case ir @ IR.Monad(code) =>
-          ZioType.fromZIO(code)
-
-        case ir @ IR.FlatMap(monad, valSymbol, body) =>
-          apply(monad).flatMappedWith(apply(body))
-
-        // Eventually a ValDef will be turned into a flatMap so if we still have one,
-        // the type-computation essentially is the same as the one for the flatMap
-        //   val symbol = assignment
-        //   bodyUsingVal
-        // Basically becomes:
-        //   assignment.flatMap { symbol =>
-        //     bodyUsingVal
-        //   }
-        // Theis essentially means that `assignment` is the monad-equivalent
-        // of flatMap and the bodyUsingVal is the body-equivalent.
-        case ir @ IR.ValDef(_, symbol, assignment, bodyUsingVal) =>
-          apply(assignment).flatMappedWith(apply(bodyUsingVal))
-
-        case ir @ IR.Map(monad, valSymbol, IR.Pure(term)) =>
-          apply(monad).mappedWith(term)
-
-        case ir @ IR.Block(head, tail) =>
-          apply(tail)
-
-        case ir @ IR.Fail(error) =>
-          // The error type often is a single expression e.g. someFunctionThatThrowsError()
-          // so we need to widen it into the underlying type
-          val bodyError = apply(error)
-          ZioType(bodyError.r, bodyError.a.widen, typeOf[Nothing])
-
-        // Things inside Unsafe blocks that are not inside runs will be wrapepd into ZIO.attempt
-        // which will make their lower-bound Throwable in the MonadifyTries phase.
-        // Do not need to do that manually here with the `e` type though.
-        case ir @ IR.Unsafe(body) =>
-          apply(body)
-
-        case ir @ IR.Match(scrutinee, caseDefs) =>
-          // Ultimately the scrutinee will be used if it is pure or lifted, either way we can
-          // treat it as a value that will be flatMapped (or Mapped) against the caseDef values.
-          val scrutineeType = apply(scrutinee)
-          // NOTE: We can possibly do the same thing as IR.Try and pass through the Match result tpe, then
-          // then use that to figure out what the type should be
-          val caseDefTypes = caseDefs.map(caseDef => apply(caseDef.rhs))
-          val caseDefTotalType = ZioType.composeN(caseDefTypes)(instructions.typeUnion)
-          scrutineeType.flatMappedWith(caseDefTotalType)
-
-        case ir @ IR.If(cond, ifTrue, ifFalse) =>
-          val condType = apply(cond)
-          val expressionType = ZioType.compose(apply(ifTrue), apply(ifFalse))
-          condType.flatMappedWith(expressionType)
-
-        case ir @ IR.And(left, right) =>
-          ZioType.compose(apply(left), apply(right))
-
-        case ir @ IR.Or(left, right) =>
-          ZioType.compose(apply(left), apply(right))
-
-        case ir @ IR.Try(tryBlock, caseDefs, outputType, finallyBlock) =>
-          val tryBlockType = apply(tryBlock)
-          // We get better results by doing into the case-defs and computing the union-type of them
-          // than we do by getting the information from outputType because outputType is limited
-          // by Scala's ability to understand the try-catch. For example, if we infer from outputType,
-          // the error-type will never be more concrete that `Throwable`.
-          // (Note, widen the error type because even if it's a concrete int type
-          // e.g. `catch { case e: Throwable => 111 }` we don't necessarily know
-          // that this error will actually happen therefore it's not sensical to make it a singleton type)
-          val caseDefType =
-            ZioType.composeN(caseDefs.map(caseDef => apply(caseDef.rhs)))(instructions.typeUnion).transformA(_.widen)
-          // Could also compute from outputType but this has worse results, see comment above.
-          // val caseDefType =
-          //   outputType.asType match
-          //     case '[ZIO[r, e, a]] => ZioType(TypeRepr.of[r].widen, TypeRepr.of[e].widen, TypeRepr.of[a].widen)
-          //     case '[t]            => ZioType(TypeRepr.of[Any].widen, TypeRepr.of[Throwable].widen, TypeRepr.of[t].widen)
-          tryBlockType.flatMappedWith(caseDefType)
-
-        case ir @ IR.While(cond, body) =>
-          val condTpe = apply(cond)
-          val bodyTpe = apply(body)
-          condTpe.flatMappedWith(bodyTpe).mappedWithType(typeOf[Unit])
-
-        case ir @ IR.Foreach(monad, _, _, body) =>
-          val monadType = apply(monad)
-          val bodyType = apply(body)
-          ZioType.fromUnitWithOthers(bodyType, monadType)(instructions.typeUnion)
-
-        case ir @ IR.Parallel(_, monadics, body) =>
-          val monadTypes =
-            monadics.map { case (monadic, _, _) => apply(monadic) }
-
-          // a IR.Leaf will either be a IR.Pure or an IR.Monad, both already have cases here
-          val bodyType = apply(body)
-
-          // For some arbitrary structure that contains monads e.g:
-          //   ((foo:ZIO[ConfA,ExA,A]).run, (bar:ZIO[ConfB,ExB,B]).run)
-          // This will turn into something like:
-          //   ZIO.collectAll(foo, bar).map(col => {val iter = col.iter; (iter.next, iter.next)}) which has the type
-          // That means that the output signature will be a ZIO of the following:
-          //   R-Parameter: ConfA & ConfB, E-Parameter: ExA | ExB, A-Parameter: (A, B)
-          // In some cases the above function will be a flatMap and wrapped into a ZIO.attempt or ZIO.succeed
-          //   so we include the body-type error and environment just in case
-          ZioType.fromPrimaryWithOthers(bodyType)(monadTypes: _*)(instructions.typeUnion)
+        case ir: IR.Leaf => handleLeaf(ir)
+        case ir: IR.Monadic => handleMonadic(ir)
       }
+
+    def handleLeaf(ir: IR.Leaf): IRT.Leaf =
+      ir match {
+        case ir: IR.Pure => handlePure(ir)
+        case ir: IR.Monad => handleMonad(ir)
+      }
+
+
+    def handleMonadic(ir: IR.Monadic): IRT.Monadic =
+      ir match {
+        case ir: IR.Monad => handleMonad(ir)
+        case ir: IR.FlatMap => handleFlatMap(ir)
+        case ir: IR.ValDef => handleValDef(ir)
+        case ir: IR.Map => handleMap(ir)
+        case ir: IR.Block => handleBlock(ir)
+        case ir: IR.Fail => handleFail(ir)
+        case ir: IR.Unsafe => handleUnsafe(ir)
+        case ir: IR.Match => handleMatch(ir)
+        case ir: IR.If => handleIf(ir)
+        case ir: IR.And => handleAnd(ir)
+        case ir: IR.Or => handleOr(ir)
+        case ir: IR.Try => handleTry(ir)
+        case ir: IR.While => handleWhile(ir)
+        case ir: IR.Foreach => handleForeach(ir)
+        case ir: IR.Parallel => handleParallel(ir)
+      }
+
+    private def handleParallel(ir: IR.Parallel) = {
+      val monadTs =
+        ir.monads.map { case (monadic, termName, tpe) => (handleMonadic(monadic), termName, tpe) }
+
+      // a IR.Leaf will either be a IR.Pure or an IR.Monad, both already have cases here
+      val bodyT = handleLeaf(ir.body)
+
+      // For some arbitrary structure that contains monads e.g:
+      //   ((foo:ZIO[ConfA,ExA,A]).run, (bar:ZIO[ConfB,ExB,B]).run)
+      // This will turn into something like:
+      //   ZIO.collectAll(foo, bar).map(col => {val iter = col.iter; (iter.next, iter.next)}) which has the type
+      // That means that the output signature will be a ZIO of the following:
+      //   R-Parameter: ConfA & ConfB, E-Parameter: ExA | ExB, A-Parameter: (A, B)
+      // In some cases the above function will be a flatMap and wrapped into a ZIO.attempt or ZIO.succeed
+      //   so we include the body-type error and environment just in case
+      val zpe = ZioType.fromPrimaryWithOthers(bodyT.zpe)(monadTs.map(_._1.zpe): _*)(instructions.typeUnion)
+      IRT.Parallel(ir.originalExpr, monadTs, bodyT)(zpe)
+    }
+
+    // The error type often is a single expression e.g. someFunctionThatThrowsError()
+    // so we need to widen it into the underlying type
+    private def handleFail(ir: IR.Fail) = {
+      val bodyError = apply(ir.error)
+      val bodyZpe = bodyError.zpe
+      val zpe = ZioType(bodyZpe.r, bodyZpe.a.widen, typeOf[Nothing])
+      IRT.Fail(bodyError)(zpe)
+    }
+
+    private def handlePure(ir: IR.Pure): IRT.Pure = IRT.Pure(ir.code)(ZioType.fromPure(ir.code))
+
+    private def handleMonad(ir: IR.Monad): IRT.Monad = IRT.Monad(ir.code)(ZioType.fromZIO(ir.code))
+
+    private def handleFlatMap(ir: IR.FlatMap): IRT.FlatMap = {
+      val monadT = handleMonadic(ir.monad)
+      val bodyT = handleMonadic(ir.body)
+      val zpe = monadT.zpe.flatMappedWith(bodyT.zpe)
+      IRT.FlatMap(monadT, ir.valSymbol, bodyT)(zpe)
+    }
+
+    private def handleBlock(ir: IR.Block): IRT.Block = {
+      val tailT = handleMonadic(ir.tail)
+      IRT.Block(ir.head, tailT)(tailT.zpe)
+    }
+
+    // Eventually a ValDef will be turned into a flatMap so if we still have one,
+    // the type-computation essentially is the same as the one for the flatMap
+    //   val symbol = assignment
+    //   bodyUsingVal
+    // Basically becomes:
+    //   assignment.flatMap { symbol =>
+    //     bodyUsingVal
+    //   }
+    // Theis essentially means that `assignment` is the monad-equivalent
+    // of flatMap and the bodyUsingVal is the body-equivalent.
+    private def handleValDef(ir: IR.ValDef) = {
+      val assignmentT = apply(ir.assignment)
+      val bodyT = apply(ir.bodyUsingVal)
+      val zpe = assignmentT.zpe.flatMappedWith(bodyT.zpe)
+      IRT.ValDef(ir.originalStmt, ir.symbol, assignmentT, bodyT)(zpe)
+    }
+
+    private def handleMap(ir: IR.Map): IRT.Map = {
+      val monadT = handleMonadic(ir.monad)
+      val bodyT = handlePure(ir.body)
+      val zpe = monadT.zpe.mappedWith(ir.body.code)
+      IRT.Map(monadT, ir.valSymbol, bodyT)(zpe)
+    }
+
+    // Things inside Unsafe blocks that are not inside runs will be wrapepd into ZIO.attempt
+    // which will make their lower-bound Throwable in the MonadifyTries phase.
+    // Do not need to do that manually here with the `e` type though.
+    private def handleUnsafe(ir: IR.Unsafe): IRT.Unsafe = {
+      val bodyT = apply(ir.body)
+      IRT.Unsafe(bodyT)(bodyT.zpe)
+    }
+
+    private def handleMatch(ir: IR.Match) = {
+      // Ultimately the scrutinee will be used if it is pure or lifted, either way we can
+      // treat it as a value that will be flatMapped (or Mapped) against the caseDef values.
+      val scrutineeT = apply(ir.scrutinee)
+      // NOTE: We can possibly do the same thing as IR.Try and pass through the Match result tpe, then
+      // then use that to figure out what the type should be
+      val caseDefTs = ir.caseDefs.map(caseDef => handleCaseDef(caseDef))
+      val caseDefTotalType = ZioType.composeN(caseDefTs.map(_.zpe))(instructions.typeUnion)
+      val zpe = scrutineeT.zpe.flatMappedWith(caseDefTotalType)
+      IRT.Match(scrutineeT, caseDefTs)(zpe)
+    }
+
+    private def handleCaseDef(ir: IR.Match.CaseDef) = {
+      val rhsT = handleMonadic(ir.rhs)
+      IRT.Match.CaseDef(ir.pattern, ir.guard, rhsT)(rhsT.zpe)
+    }
+
+    private def handleIf(ir: IR.If) = {
+      val condT = apply(ir.cond)
+      val ifTrueT = apply(ir.ifTrue)
+      val ifFalseT = apply(ir.ifFalse)
+      val expressionType = ZioType.compose(ifTrueT.zpe, ifFalseT.zpe)
+      val zpe = condT.zpe.flatMappedWith(expressionType)
+      IRT.If(condT, ifTrueT, ifFalseT)(zpe)
+    }
+
+    private def handleAnd(ir: IR.And) = {
+      val leftT = apply(ir.left)
+      val rightT = apply(ir.right)
+      val zpe = ZioType.compose(leftT.zpe, rightT.zpe)
+      IRT.And(leftT, rightT)(zpe)
+    }
+
+    private def handleOr(ir: IR.Or) = {
+      val leftT = apply(ir.left)
+      val rightT = apply(ir.right)
+      val zpe = ZioType.compose(leftT.zpe, rightT.zpe)
+      IRT.Or(leftT, rightT)(zpe)
+    }
+
+    private def handleTry(ir: IR.Try) = {
+      val tryBlockT = apply(ir.tryBlock)
+      val caseTs = ir.cases.map(handleCaseDef)
+      val finallyT = ir.finallyBlock.map(apply)
+      // We get better results by doing into the case-defs and computing the union-type of them
+      // than we do by getting the information from outputType because outputType is limited
+      // by Scala's ability to understand the try-catch. For example, if we infer from outputType,
+      // the error-type will never be more concrete that `Throwable`.
+      // (Note, widen the error type because even if it's a concrete int type
+      // e.g. `catch { case e: Throwable => 111 }` we don't necessarily know
+      // that this error will actually happen therefore it's not sensical to make it a singleton type)
+      val caseDefType =
+      ZioType.composeN(caseTs.map(_.zpe))(instructions.typeUnion).transformA(_.widen)
+      // Could also compute from outputType but this has worse results, see comment above.
+      // val caseDefType =
+      //   outputType.asType match
+      //     case '[ZIO[r, e, a]] => ZioType(TypeRepr.of[r].widen, TypeRepr.of[e].widen, TypeRepr.of[a].widen)
+      //     case '[t]            => ZioType(TypeRepr.of[Any].widen, TypeRepr.of[Throwable].widen, TypeRepr.of[t].widen)
+      val zpe = tryBlockT.zpe.flatMappedWith(caseDefType)
+      IRT.Try(tryBlockT, caseTs, ir.resultType, finallyT)(zpe)
+    }
+
+    private def handleWhile(ir: IR.While) = {
+      val condT = apply(ir.cond)
+      val bodyT = apply(ir.body)
+      val zpe = condT.zpe.flatMappedWith(bodyT.zpe).mappedWithType(typeOf[Unit])
+      IRT.While(condT, bodyT)(zpe)
+    }
+
+    private def handleForeach(ir: IR.Foreach) = {
+      val listT = apply(ir.list)
+      val bodyT = apply(ir.body)
+      val zpe = ZioType.fromUnitWithOthers(bodyT.zpe, listT.zpe)(instructions.typeUnion)
+      IRT.Foreach(listT, ir.listType, ir.elementSymbol, bodyT)(zpe)
+    }
   }
 }

--- a/zio-direct/src/main/scala-2.x/zio/direct/core/norm/WithReconstructTree.scala
+++ b/zio-direct/src/main/scala-2.x/zio/direct/core/norm/WithReconstructTree.scala
@@ -122,13 +122,13 @@ trait WithReconstructTree extends MacroBase {
         case IR.Fail(error) =>
           error match {
             case IR.Pure(value) =>
-              val tpe = ComputeType.fromIR(error).a.widen
+              val tpe = ComputeType.fromIR(error).zpe.a.widen
               q"zio.ZIO.fail[$tpe](${value})"
 
             // TODO test the case where error is constructed via an run
             case m: IR.Monadic =>
               val monad = apply(m)
-              val a = ComputeType.fromIR(error).a
+              val a = ComputeType.fromIR(error).zpe.a
               q"$monad.flatMap(err => zio.ZIO.fail[$a](err))"
           }
 
@@ -190,7 +190,7 @@ trait WithReconstructTree extends MacroBase {
         case irWhile @ IR.While(whileCond, whileBody) =>
           // Since the function needs to know the type for the definition (especially because it's recursive!) need to find that out here
           val methOutputComputed = ComputeType.fromIR(irWhile)
-          val methOutputTpe = methOutputComputed.toZioType
+          val methOutputTpe = methOutputComputed.zpe.toZioType
 
           // val methodType = MethodType(Nil)(_ => Nil, _ => methOutputTpe)
           // val methSym = Symbol.newMethod(Symbol.spliceOwner, "whileFunc", methodType)
@@ -226,7 +226,7 @@ trait WithReconstructTree extends MacroBase {
           ComputeType.fromIR(tryBlock)
           val newCaseDefs = reconstructCaseDefs(cases)
           val tryTerm = apply(tryBlock)
-          val (r, e, a) = ComputeType.fromIR(tryIR).asTypeTuple
+          val (r, e, a) = ComputeType.fromIR(tryIR).zpe.asTypeTuple
 
           // need to cast to .asInstanceOf[zio.ZIO[$r, _, $a]] erasing the type _ since it could be
           // `Nothing` and then ZIO returns the following error:


### PR DESCRIPTION
**WIP**: 
* Created IRT - the typed version of `IR` AST
* WithComputeType: extracting `IRT` instead of `IR`