### PR TITLE
Improved mutable collection error message

### DIFF
--- a/zio-direct-test/src/test/scala-3.x/zio/direct/DeferRunSpec.scala
+++ b/zio-direct-test/src/test/scala-3.x/zio/direct/DeferRunSpec.scala
@@ -112,7 +112,6 @@ trait DeferRunSpec extends ZIOSpecDefault {
     val errors =
       typeCheckErrors("defer({" + body + "})").map(_.message)
 
-    // assert(errors)(exists(containsString(errorStringContains)))
     zio.test.UseSmartAssert.of(errors, None, None)(exists(containsString(errorStringContains)))(sourceLocation)
   }
 

--- a/zio-direct-test/src/test/scala/zio/direct/MutableSpec.scala
+++ b/zio-direct-test/src/test/scala/zio/direct/MutableSpec.scala
@@ -63,7 +63,7 @@ object MutableSpec extends DeferRunSpec {
       test("plain not allowed") {
         var buff = new ArrayBuffer[Int]()
         buff += 1
-        runLiftFailMsg(Messages.MutableCollectionDetected("ArrayBuffer")) {
+        runLiftFailMsg(Messages.MutableCollectionDetected("ArrayBuffer", "buff")) {
           """
           buff.update(0, buff(0) + 1); buff(0)
           """

--- a/zio-direct-test/src/test/scala/zio/direct/VariaSpec.scala
+++ b/zio-direct-test/src/test/scala/zio/direct/VariaSpec.scala
@@ -135,7 +135,7 @@ object VariaSpec extends DeferRunSpec { //
       test("disallow mutable collection use") {
         import scala.collection.mutable.ArrayBuffer
         val v = new ArrayBuffer[Int](4)
-        runLiftFailMsg(Messages.MutableCollectionDetected("ArrayBuffer")) {
+        runLiftFailMsg(Messages.MutableCollectionDetected("ArrayBuffer", "v.+=(4)")) {
           """
           v += 4
           """
@@ -143,7 +143,7 @@ object VariaSpec extends DeferRunSpec { //
       },
       test("disallow mutable collection use - declare but not use") {
         import scala.collection.mutable.ArrayBuffer
-        runLiftFailMsg(Messages.MutableCollectionDetected("ArrayBuffer")) {
+        runLiftFailMsg(Messages.MutableCollectionDetected("ArrayBuffer", "new scala.collection.mutable.ArrayBuffer[scala.Int](4)")) {
           """
           val v = new ArrayBuffer[Int](4)
           ZIO.succeed(123).run

--- a/zio-direct/src/main/scala-2.x/zio/direct/core/metaprog/WithAllowed.scala
+++ b/zio-direct/src/main/scala-2.x/zio/direct/core/metaprog/WithAllowed.scala
@@ -158,7 +158,10 @@ trait WithAllowed extends MacroBase {
             Unsupported.Error.withTree(asi, Messages.AssignmentNotAllowed)
 
           case _ if (FromMutablePackage.check(expr.tpe)) =>
-            Unsupported.Error.withTree(expr, Messages.MutableCollectionDetected(expr.tpe.typeSymbol.name.toString, PrintAny(expr)))
+            Unsupported.Error.withTree(expr, Messages.MutableCollectionDetected(
+              expr.tpe.typeSymbol.name.toString,
+              Format(Format.Tree(expr))
+            ))
 
           // All the kinds of valid things a Term can be in defer blocks
           // Originally taken from TreeMap.transformTerm in Quotes.scala

--- a/zio-direct/src/main/scala-2.x/zio/direct/core/metaprog/WithAllowed.scala
+++ b/zio-direct/src/main/scala-2.x/zio/direct/core/metaprog/WithAllowed.scala
@@ -6,7 +6,7 @@ import zio.direct.core.util.Messages
 import zio.Chunk
 
 trait WithAllowed extends MacroBase {
-  self: WithUnsupported with WithAllowedCompat =>
+  self: WithUnsupported with WithAllowedCompat with WithPrintIR =>
 
   import c.universe._
 
@@ -158,7 +158,7 @@ trait WithAllowed extends MacroBase {
             Unsupported.Error.withTree(asi, Messages.AssignmentNotAllowed)
 
           case _ if (FromMutablePackage.check(expr.tpe)) =>
-            Unsupported.Error.withTree(expr, Messages.MutableCollectionDetected(expr.tpe.typeSymbol.name.toString))
+            Unsupported.Error.withTree(expr, Messages.MutableCollectionDetected(expr.tpe.typeSymbol.name.toString, PrintAny(expr)))
 
           // All the kinds of valid things a Term can be in defer blocks
           // Originally taken from TreeMap.transformTerm in Quotes.scala

--- a/zio-direct/src/main/scala-3.x/zio/direct/core/Allowed.scala
+++ b/zio-direct/src/main/scala-3.x/zio/direct/core/Allowed.scala
@@ -190,7 +190,7 @@ object Allowed {
 
         // check if the statement is a mutable collect (if it is not a block)
         case NotBlock.Term(_) if (FromMutablePackage.check(expr.tpe)) =>
-          Unsupported.Error.withTree(expr, Messages.MutableCollectionDetected(expr.tpe.typeSymbol.name))
+          Unsupported.Error.withTree(expr, Messages.MutableCollectionDetected(expr.tpe.typeSymbol.name, expr.show))
 
         // All the kinds of valid things a Term can be in defer blocks
         // Originally taken from TreeMap.transformTerm in Quotes.scala

--- a/zio-direct/src/main/scala/zio/direct/core/util/Messages.scala
+++ b/zio-direct/src/main/scala/zio/direct/core/util/Messages.scala
@@ -14,11 +14,16 @@ val ImplicitsNotAllowed =
 Implicits are not allowed inside defer clauses (they are allowed inside of `run(...)` blocks.
 """.trimLeft
 
-def MutableCollectionDetected(name: String) =
+def MutableCollectionDetected(name: String, expr: String) =
 s"""
 Detected the use of a mutable collection inside a defer clause (called: ${name}).
+They must be wrapped in a ZIO effect and called with `run` in order to be safe.
+Example:
+
+   ZIO.attempt($expr).run
+
 Mutable collections can cause many potential issues as a result of defer-clause
-rewrites so they are not allowed (Unless it is inside of a run-call).
+rewrites if not wrapped.
 """.trimLeft
 
 val DeclarationNotAllowedWithRuns =

--- a/zio-direct/src/test/scala-2.x/zio/direct/testing/TestSupport.scala
+++ b/zio-direct/src/test/scala-2.x/zio/direct/testing/TestSupport.scala
@@ -113,10 +113,7 @@ private[direct] class TestSupportMacro(val c: Context) extends Transformer {
   def runLiftFailMsg[T](msg: Tree)(body: Tree): Tree = {
     val bodyStr = requireConstString(body)
     val (fails, failMsg) = doTypecheck(wrapDefer(bodyStr))
-
-    q"""{
-       |zio.test.assertTrue(true)
-       |}""".stripMargin
+    q"zio.test.assertTrue($fails) && zio.test.assert($failMsg)(zio.test.Assertion.containsString($msg))"
   }
 
   def runLiftFailLenientMsg[T](msg: Tree)(body: Tree): Tree = {

--- a/zio-direct/src/test/scala-2.x/zio/direct/testing/TestSupport.scala
+++ b/zio-direct/src/test/scala-2.x/zio/direct/testing/TestSupport.scala
@@ -113,7 +113,10 @@ private[direct] class TestSupportMacro(val c: Context) extends Transformer {
   def runLiftFailMsg[T](msg: Tree)(body: Tree): Tree = {
     val bodyStr = requireConstString(body)
     val (fails, failMsg) = doTypecheck(wrapDefer(bodyStr))
-    q"zio.test.assertTrue($fails) && zio.test.assert($failMsg)(zio.test.Assertion.containsString($msg))"
+
+    q"""{
+       |zio.test.assertTrue(true)
+       |}""".stripMargin
   }
 
   def runLiftFailLenientMsg[T](msg: Tree)(body: Tree): Tree = {


### PR DESCRIPTION
I know 2 people now that have been thrown off by the current error message.
They read up to:
`Mutable collections can cause many potential issues as a result of defer-clause rewrites so they are not allowed` and then got frustrated and stopped because they got the impression that there was _no_ way to use mutable collections with zio-direct.

Even though the very next clause tells you how to make it work, I think we can improve the user experience by leading with the solution. Now  the message looks like this:
<img width="1664" alt="Screenshot 2023-04-30 at 10 19 24 PM" src="https://user-images.githubusercontent.com/2054940/235406836-218971d8-512f-43b9-ba5c-8b3acbb59ff3.png">

The test case changes could probably be more specific, but I was having trouble tweaking this code to enable that-
```
  transparent inline def runLiftFailMsg(errorStringContains: String)(body: String) = {
    val errors =
      typeCheckErrors("defer({" + body + "})").map(_.message)
      
    zio.test.UseSmartAssert.of(errors, None, None)(exists(containsString(errorStringContains)))(sourceLocation)
  }
```