### PR TITLE
support run method without extension syntax

### DIFF
--- a/zio-direct-test/src/test/scala-3.x/zio/direct/RunSpec.scala
+++ b/zio-direct-test/src/test/scala-3.x/zio/direct/RunSpec.scala
@@ -1,0 +1,24 @@
+package zio.direct
+
+import zio.direct.{run => runBlock}
+import zio.test._
+import zio.test.Assertion._
+import zio._
+import ZIO.{unsafe => _, _}
+import zio.direct.core.util.Messages
+import scala.annotation.nowarn
+
+@nowarn
+object RunSpec extends DeferRunSpec {
+
+  val spec = suite("RunSpec")(
+    test("supports run method without extension syntax") {
+      @directRunCall
+      def await[T](v: Task[T]): T = ???
+      class Blah(val value: Int)
+      runLiftTest(1) {
+        await(ZIO.succeed(1))
+      }
+    }
+  )
+}

--- a/zio-direct/src/main/scala-3.x/zio/direct/core/metaprog/Extractor.scala
+++ b/zio-direct/src/main/scala-3.x/zio/direct/core/metaprog/Extractor.scala
@@ -133,6 +133,8 @@ object Extractors {
       tree match
         case DottyExtensionCall.OneArg(invocation @ DirectRunCallAnnotated.Term(), effect) =>
           Some(effect.asExpr)
+        case quotes.reflect.Apply(quotes.reflect.TypeApply(invocation @ DirectRunCallAnnotated.Term(), _), effect :: Nil) =>
+          Some(effect.asExpr)
         case _ =>
           None
     }


### PR DESCRIPTION
I'm replacing dotty-cps-async in Kyo by zio-direct. Kyo uses `defer`/`await` but the `await` is a regular method instead of an extension